### PR TITLE
update ocular scripts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 printWidth: 100
 semi: false
 singleQuote: true
-trailingComma: all

--- a/templates/doc.js
+++ b/templates/doc.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+module.exports = res => `## Getting started
+
+Add your documentation in the src/docs/ folders in markdown format. For more information and examples, check out ocular documentation.
+`;

--- a/templates/mdRoutes.js
+++ b/templates/mdRoutes.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+module.exports = res => `import gettingStarted from 'docs/getting-started.md';
+
+export default [{
+  name: "Documentation",
+  path: "/docs",
+  data: [{
+    name: "Getting started",
+    markdown: gettingStarted
+  }]
+}];
+`;

--- a/website/src/docs/config-reference.md
+++ b/website/src/docs/config-reference.md
@@ -1,4 +1,4 @@
-# Configurtion Reference
+# Configuration Reference
 
 ## PROJECT_TYPE
 


### PR DESCRIPTION
WRT issue #20. 

init now adds a starter documentation file in /src/docs, and mdRoutes starts not empty. 
there are 2 extra scripts - clean and publish. 
Those 2 are often manually added by ocular users. 
the idea is that publish will move compiled files from /dist to a destination folder, from where the website will be served. In the typical architecture of a repo with ocular:

/website/ is where all the ocular stuff will take place,
/website/src has custom components, markdown files...
/website/dist has the compiled files once ocular build is ran

/docs is where the final website will be served, and it works well with the github pages option of having a github pages website on "the /docs folder of the master branch." 
 
With that in mind,
clean will remove compiled files from /docs, and publish will run clean, build, then move the compiled files to /docs. Now all the user has to do is to push this branch on github. 


