### PR TITLE
better handling of empty route

### DIFF
--- a/base/components/Wrapper.js
+++ b/base/components/Wrapper.js
@@ -36,8 +36,8 @@ class Wrapper extends Component {
   }
 
   render() {
-    const { markdown, markdownUrl, component } = this.props
-    const Comp = markdown || markdownUrl ? Markdown : component
+    const { component } = this.props
+    const Comp = component || Markdown
     return (
       <div className="f fg">
         <div className="f fg container page">


### PR DESCRIPTION
When there's a documentation route which either has neither has:
* a markdown property, which is truthy,
* a valid markdownUrl property,
* a valid component property

This results in an error. With this fix this will result in an empty page but won't crash the site, so further navigation is possible. 