### PR TITLE
supports renaming of folder even when using custom docs path

### DIFF
--- a/utils/build-docs.js
+++ b/utils/build-docs.js
@@ -28,7 +28,7 @@ function listDocs(docsSrcPath) {
         const docTitleFromContent =
           docFirstLine.startsWith('#') && docFirstLine.replace(/^#+\s*/, '')
 
-        const docBaseName = docTitleFromContent || docBaseNameFromFileName
+        const docBaseName = docTitleFromContent || sentence(docBaseNameFromFileName)
 
         const componentName = `_${camel(path.concat(docBaseName).join('-'))}`
 
@@ -72,14 +72,15 @@ function buildMdRoutes(docs, docsSrcPath, websitePath) {
 
       const pathSuffix = path
       let destination = result.data
-      let currentPath = '/docs'
-
+      let currentPath = fileLocationBase
+      let titlePath = docsSrcPath
       pathSuffix.forEach(p => {
         const size = destination.length
         currentPath = `${currentPath}/${p}`
+        titlePath = `${titlePath}/${p}`
 
-        const name = existsSync(`src/${currentPath}/TITLE`)
-          ? readFileSync(`src/${currentPath}/TITLE`, 'UTF-8')
+        const name = existsSync(`${titlePath}/TITLE`)
+          ? readFileSync(`${titlePath}/TITLE`, 'UTF-8')
           : sentence(p)
 
         let nextLevelIdx = destination.findIndex(d => d.fullPath === currentPath)
@@ -97,7 +98,7 @@ function buildMdRoutes(docs, docsSrcPath, websitePath) {
 
       destination.push({
         fileLocation: normalize(join(fileLocationBase, path.join('/'), fileName)),
-        name: sentence(docBaseName),
+        name: docBaseName,
         markdown: componentName
       })
     })


### PR DESCRIPTION
This PR fixes 2 issues. 
the first is that after custom docs source path was allowed, the feature through which users can override name of folders didn't support that. The app wouldn't break, only the folders wouldn't be renamed as expected. 

The second change is on how sentence case is being applied to documentation pages names.
It used to be that sentence case was applied regardless. So if your file name was gpu-optimization.md, the rendered title would be "G p u optimization", and if the file started by 
```
# GPU Optimization
```
then the rendered title would be exactly the same. Now, if the title comes from the title of the document, not just the file name, sentence case is not applied, the title is taken as is. 

 