### PR TITLE
honor-file-location-based-links

### DIFF
--- a/base/utils/markdown-rendering-utils.js
+++ b/base/utils/markdown-rendering-utils.js
@@ -1,0 +1,74 @@
+import routes from 'routes'
+import { HISTORY } from 'config'
+import path from 'path'
+
+export const findClosestRoute = (matchedText, routeList, searchPath) => {
+  if (routeList.length === 0) {
+    return undefined
+  }
+  if (routeList.length === 1) {
+    // if there's only one route, that's the one
+    return routeList[0]
+  }
+  if (!searchPath) {
+    // Recursion base case
+    // If searchPath is empty, return the first route that has "/" before the text.
+    // If that also fails, return the first route of the list.
+    return routeList.find(r => r.path.includes(`/${matchedText}`)) || routeList[0]
+  }
+  // If a route exist on the currentPath, return that one.
+  // If not, iterate one step up on the path
+  const reducedSearchPath = searchPath.replace(/^(.*)\/.*$/, '$1')
+  return (
+    routeList.find(r => r.path.includes(`${reducedSearchPath}/${matchedText}`)) ||
+    findClosestRoute(matchedText, routeList, reducedSearchPath)
+  )
+}
+
+export const fallBack = ({ className, href, text }) => {
+  return `<a class=${className} href=${href}>${text}</a>`
+}
+
+export const getRouteFromFileLocation = (routeFileLocation, href) => {
+  if (!routeFileLocation) {
+    return undefined
+  }
+  const routePath = path.dirname(routeFileLocation)
+  return routes.find(r =>
+    // href contains the absolute location of a markdown file as specified in the routes definition
+    href === r.fileLocation ||
+    // href contains a relative link to a markdown file
+    path.resolve(routePath, href) === r.fileLocation)
+}
+
+export const linkRenderer = (routePath, routeFileLocation) => (href, title, text) => {
+  // starts with http:// or https:// ?
+  const isFull = /^(https?:\/\/)/.test(href)
+
+  // part of the href string between / character and end of string (ignoring final .md extension)
+  const match = href.replace(/.*\/(.*)$/, '$1').replace(/\.md$/, '')
+  if (isFull || !match) {
+    return fallBack({ className: 'raw-link', href, text })
+  }
+
+  // attempt #1: if the link points to a file, and a route has this file as its fileLocation property,
+  // returns route to this file.
+  const routeFromFileLocation = getRouteFromFileLocation(routeFileLocation, href)
+
+  // attempt #2: if no route is found with this solution, then tries to find a route that has a path
+  // that corresponds to the part described on line 35.
+  const matchingRoutes = routes.filter(r => r.path.includes(match))
+  const routeFromPath = findClosestRoute(match, matchingRoutes, routePath)
+
+  const route = routeFromFileLocation || routeFromPath
+
+  // if a route isn't found either way, then we use the href link as is.
+  if (!route) {
+    return fallBack({ className: 'not-matched-link', href, text })
+  }
+
+  const addPrefix = HISTORY !== 'browser' && route.path.indexOf('/#') !== 0
+  return `<a ${HISTORY === 'browser' ? 'useHistory' : ''} href="${addPrefix ? '/#' : ''}${
+    route.path
+  }">${text}</a>`
+}

--- a/website/src/docs/reference/build-your-own-components/2-app/1-App.md
+++ b/website/src/docs/reference/build-your-own-components/2-app/1-App.md
@@ -1,6 +1,6 @@
 # App.js
 
 App.js is the root component of your ocular website. It contains the routes system.
-It also includes the [Header](./header) and the [Toc](./toc) components.
+It also includes the [Header](/website/src/docs/reference/build-your-own-components/2-app/2-Header.md) and the [Toc](./toc) components.
 
 Finally, it also offers google analytics tracking, if you specified a GA_TRACKING key in your configuration file.

--- a/website/src/docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md
+++ b/website/src/docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md
@@ -1,0 +1,56 @@
+# Links between documentation pages
+
+In addition to links in the [Header](/website/src/docs/reference/build-your-own-components/2-app/2-Header.md) (either [default](./default-links) or [custom](./additional-links)), you can have links in your documentation pages using the markdown syntax: 
+
+```
+[label of link](where the link points to)
+```
+
+That said, there are several ways the links can work.
+
+| Case                                | Syntax                                                                                                            | Link                                                                                                       |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| External link                       | ```[Uber engineering blog](http://eng.uber.com)```                                                                | [Uber engineering blog](http://eng.uber.com)                                                               |
+| Full link to a page within the site | ```[Ocular home page](https://uber-web.github.io/ocular/)```                                                      | [Ocular home page](https://uber-web.github.io/ocular/)                                                     |
+| Absolute link to a markdown file    | ```[a link to this page] (/website/src/docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md)``` | [a link to this page](/website/src/docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md) |
+| Relative link to a markdown file in same folder   | ```[Introduction](./introduction.md)```                                                                           | [Introduction](./introduction.md)                                                                          |
+| Relative link to a markdown file in same folder, omitting ./   | ```[Introduction](introduction.md)```                                                                           | [Introduction](introduction.md)                                                                          |
+| Relative link to a markdown file in a different folder   | ```[Getting started](../../basics/2-getting-started.md)```                                                                           | [Getting started](../../basics/2-getting-started.md)                                                                          |
+| Relative link to a route            | ```[Introduction](./introduction)```                                                                              | [Introduction](./introduction)                                                                             |
+| Another relative link to a route            | ```[Getting started](../../basics/quick-start)```                                                                              | [Getting started](../../basics/quick-start)                                                                             |
+
+## Link to a full url
+
+If you make your link point to a full url (ie 'http://eng.uber.com') then Ocular will not transform it. [Uber engineering blog](http://eng.uber.com)
+```
+[Uber engineering blog](http://eng.uber.com)
+```
+
+Note that you can also have full, absolute links pointing inside your documentation site.
+[Ocular home page](https://uber-web.github.io/ocular/)
+```
+[Ocular home page](https://uber-web.github.io/ocular/)
+```
+
+## link to a markdown file
+
+If, in your markdown files, you have a link to another markdown file, that link will still work from one Ocular page to another. The condition is that it your routes must have a fileLocation property documented. Note you have it automatically if you use [automatic route generation](/website/src/docs/reference/routes-and-links-in-ocular/2-documentation-routes.md)
+
+This either works with absolute links (ie the whole path of the file is given, starting with a '/'), or with relative links (ie the path is relative to the directory of the source file). For files in the same directories, you can just use the file name directly without prefixing it with './'.
+
+## link from a route to a route
+
+Finally, you can use relative links from a route to a route. [Here's a link to the introduction page](./introduction) and its markdown equivalent: 
+```
+[Here's a link to the introduction page](./introduction)
+```
+These link will work in the Ocular pages even though they will not work in the source markdown documents.
+
+## Which to use?
+
+The distinction between file-to-file and route-to-route links is important because files and routes don't necessarily have the same in Ocular. 
+
+Route-to-route links are conceptually simpler if you don't care / don't expose the source markdown files. 
+They will still work if the underlying files change names. 
+
+File-to-file links work both in the source material (ie if your source markdown files are in the /docs folder of your GitHub repository). Absolute file-to-file links can be copy/pasted around in various parts of your documentation. However these links will break if your file change names or locations. 

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -15,6 +15,7 @@ import _referenceRoutesAndLinksInOcularDocumentationRoutes from 'docs/reference/
 import _referenceRoutesAndLinksInOcularCustomPages from 'docs/reference/routes-and-links-in-ocular/3-custom-pages.md'
 import _referenceRoutesAndLinksInOcularDefaultLinks from 'docs/reference/routes-and-links-in-ocular/4-default-links.md'
 import _referenceRoutesAndLinksInOcularAdditionalLinks from 'docs/reference/routes-and-links-in-ocular/5-additional-links.md'
+import _referenceRoutesAndLinksInOcularLinksBetweenDocumentationPages from 'docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md'
 import _referenceStylingOcularIntroductionToStyling from 'docs/reference/styling-ocular/1-introduction.md'
 import _referenceStylingOcularTheDefaultStyleModules from 'docs/reference/styling-ocular/2-default-style-modules.md'
 import _referenceStylingOcularCustomizingFonts from 'docs/reference/styling-ocular/3-customizing-fonts.md'
@@ -49,7 +50,7 @@ export default [{
           children: [
             {
               fileLocation: "/website/src/docs/reference/build-your-own-components/1-presenting-base-components.md",
-              name: "Presenting ocular's base components",
+              name: "Presenting Ocular's base components",
               markdown: _referenceBuildYourOwnComponentsPresentingOcularSBaseComponents
             },
             {
@@ -58,17 +59,17 @@ export default [{
               children: [
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/2-app/1-App.md",
-                  name: "App js",
+                  name: "App.js",
                   markdown: _referenceBuildYourOwnComponents2AppAppJs
                 },
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/2-app/2-Header.md",
-                  name: "Header js",
+                  name: "Header.js",
                   markdown: _referenceBuildYourOwnComponents2AppHeaderJs
                 },
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/2-app/3-Toc.md",
-                  name: "Toc js",
+                  name: "Toc.js",
                   markdown: _referenceBuildYourOwnComponents2AppTocJs
                 }
               ]
@@ -79,17 +80,17 @@ export default [{
               children: [
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/3-home/1-Home.md",
-                  name: "Home js",
+                  name: "Home.js",
                   markdown: _referenceBuildYourOwnComponents3HomeHomeJs
                 },
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/3-home/2-Hero.md",
-                  name: "Hero js",
+                  name: "Hero.js",
                   markdown: _referenceBuildYourOwnComponents3HomeHeroJs
                 },
                 {
                   fileLocation: "/website/src/docs/reference/build-your-own-components/3-home/3-Footer.md",
-                  name: "Footer js",
+                  name: "Footer.js",
                   markdown: _referenceBuildYourOwnComponents3HomeFooterJs
                 }
               ]
@@ -112,7 +113,7 @@ export default [{
           children: [
             {
               fileLocation: "/website/src/docs/reference/configurating-ocular/config-reference.md",
-              name: "Configuration reference",
+              name: "Configuration Reference",
               markdown: _referenceConfiguratingOcularConfigurationReference
             }
           ]
@@ -133,7 +134,7 @@ export default [{
             },
             {
               fileLocation: "/website/src/docs/reference/routes-and-links-in-ocular/3-custom-pages.md",
-              name: "Custom pages",
+              name: "Custom Pages",
               markdown: _referenceRoutesAndLinksInOcularCustomPages
             },
             {
@@ -145,6 +146,11 @@ export default [{
               fileLocation: "/website/src/docs/reference/routes-and-links-in-ocular/5-additional-links.md",
               name: "Additional links",
               markdown: _referenceRoutesAndLinksInOcularAdditionalLinks
+            },
+            {
+              fileLocation: "/website/src/docs/reference/routes-and-links-in-ocular/6-links-between-documentation-pages.md",
+              name: "Links between documentation pages",
+              markdown: _referenceRoutesAndLinksInOcularLinksBetweenDocumentationPages
             }
           ]
         },


### PR DESCRIPTION
With this PR links from a markdown document to a markdown document, in the source material, are honored once these documents are transformed into Ocular pages. 