### PR TITLE
rewrite local links

### DIFF
--- a/modules/gatsby/src/gatsby-node/create-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-pages.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const assert = require('assert');
 
-const {log, COLOR} = require('../utils/log');
+const { log, COLOR } = require('../utils/log');
 
 // PATHS TO REACT PAGES
 const INDEX_PAGE = path.resolve(__dirname, '../templates/index.jsx');
@@ -22,7 +22,7 @@ assert(INDEX_PAGE && DOC_PAGE && EXAMPLES_PAGE && EXAMPLE_PAGE);
 // by gatsby.
 // We use graphgl to query for nodes and iterate
 module.exports = function createPages({ graphql, actions }, pluginOptions) {
-  log.log({color: COLOR.CYAN}, 'generating pages')();
+  log.log({ color: COLOR.CYAN }, 'generating pages')();
 
   // TODO/ib - plugin options no longer provided when we are not a plugin
   // We seem to be getting site metadata instead?
@@ -44,7 +44,7 @@ module.exports = function createPages({ graphql, actions }, pluginOptions) {
   }
 
   return Promise.all([docPromise, examplesPromise]);
-}
+};
 
 // Create static pages
 // NOTE: gatsby does automatically build pages from **top level** `/pages`, folder
@@ -55,9 +55,8 @@ function createStaticPages({ graphql, actions }) {
 
   createPage({
     component: INDEX_PAGE,
-    path: '/',
+    path: '/'
   });
-
 }
 
 function createExamplePages({ graphql, actions }) {
@@ -76,8 +75,7 @@ function createExamplePages({ graphql, actions }) {
         }
       }
     }
-  `)
-  .then(result => {
+  `).then(result => {
     console.log(result);
 
     if (result.errors) {
@@ -86,7 +84,7 @@ function createExamplePages({ graphql, actions }) {
       throw new Error(result.errors);
     }
 
-    const {EXAMPLES} = result.data.site.siteMetadata.config;
+    const { EXAMPLES } = result.data.site.siteMetadata.config;
 
     // If the no examples marker, return without creating pages
     if (EXAMPLES.length === 0 || EXAMPLES[0].title === 'none') {
@@ -104,8 +102,10 @@ function createExamplePages({ graphql, actions }) {
     for (const example of EXAMPLES) {
       const exampleName = example.title;
 
-      log.log({color: COLOR.CYAN, priority: 1},
-        `Creating example page ${JSON.stringify(example)}`)();
+      log.log(
+        { color: COLOR.CYAN, priority: 1 },
+        `Creating example page ${JSON.stringify(example)}`
+      )();
 
       createPage({
         path: example.path,
@@ -141,15 +141,26 @@ function createDocPages({ graphql, actions }) {
             }
           }
         }
+        site {
+          siteMetadata {
+            config {
+              ROOT_FOLDER
+            }
+          }
+        }
       }
     `
-  )
-  .then(result => {
+  ).then(result => {
     if (result.errors) {
       /* eslint no-console: "off" */
       console.log(result.errors);
       throw new Error(result.errors);
     }
+    const rootFolder = result.data.site.siteMetadata.config.ROOT_FOLDER;
+    const pathToSlug = result.data.allMarkdownRemark.edges.map(({ node }) => ({
+      source: node.fileAbsolutePath,
+      target: node.fields.slug
+    }));
 
     const tagSet = new Set();
     const categorySet = new Set();
@@ -164,12 +175,57 @@ function createDocPages({ graphql, actions }) {
         categorySet.add(edge.node.frontmatter.category);
       }
 
+      const relativeLinks = pathToSlug.reduce((prev, { source, target }) => {
+        // what we are doing here: for each markdown file, we create a mapping of different ways to
+        // link to another markdown file that we will honor.
+
+        // let's suppose that we want to go from a file:
+        // - physical location: /docs/my-files/source.md, slug: /docs/chapter-1/source
+        // to this file:
+        // - phyiscal location: /docs/developer-guide/target.md, slug: /docs/advanced-usage/api-reference/target
+
+        // by default, '../../advanced-usage/api/reference/target' would work (target file slug, relative to original slug)
+        // '/docs/advanced-usage/api-reference/target' would also work (absolute target slug)
+        // however, on github, those links wouldn't work as there is no phyiscal file behind that link.
+        // in github however: '/docs/developer-guide/target.md' (file name relative to root) or
+        // '../developer-guide/target.md' (relative file name) would work. Those links wouldn't work on the gatsby rendered
+        // page however (until that).
+
+        // we are creating a mapping so that ANY OF THESE 4 SYNTAXES would be honored.
+        // So, authors can use links that refer to physical files, and gatsby will render a link that works - the same link
+        // can work on github and gatsby
+
+        // note that often, the physical location and the slug are the same!
+        // However there is no guarantee that this will be the case.
+
+        const relativeToCurrentFile = path.relative(
+          edge.node.fileAbsolutePath,
+          source
+        );
+        const relativeToRootFolder = path.relative(rootFolder, source);
+        const relativeToCurrentSlug = path.relative(
+          edge.node.fields.path,
+          target
+        );
+
+        const absoluteTarget = `/${target}`;
+
+        return {
+          ...prev,
+          [relativeToCurrentFile]: absoluteTarget,
+          [relativeToRootFolder]: absoluteTarget,
+          [relativeToCurrentSlug]: absoluteTarget,
+          [target]: absoluteTarget
+        };
+      }, {});
+
       // console.log('Creating doc page at', edge.node.fields.path);
 
       createPage({
         path: edge.node.fields.path,
         component: DOC_PAGE,
         context: {
+          relativeLinks,
           slug: edge.node.fields.path,
           toc: 'docs'
         }

--- a/modules/gatsby/src/gatsby-node/create-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-pages.js
@@ -119,6 +119,54 @@ function createExamplePages({ graphql, actions }) {
   });
 }
 
+function addToRelativeLinks({
+  source,
+  target,
+  rootFolder,
+  edge,
+  relativeLinks
+}) {
+  // what we are doing here: for each markdown file, we create a mapping of different ways to
+  // link to another markdown file that we will honor.
+
+  // let's suppose that we want to go from a file:
+  // - physical location: /docs/my-files/source.md, slug: /docs/chapter-1/source
+  // to this file:
+  // - phyiscal location: /docs/developer-guide/target.md, slug: /docs/advanced-usage/api-reference/target
+
+  // by default, '../../advanced-usage/api/reference/target' would work (target file slug, relative to original slug)
+  // '/docs/advanced-usage/api-reference/target' would also work (absolute target slug)
+  // however, on github, those links wouldn't work as there is no phyiscal file behind that link.
+  // in github however: '/docs/developer-guide/target.md' (file name relative to root) or
+  // '../developer-guide/target.md' (relative file name) would work. Those links wouldn't work on the gatsby rendered
+  // page however (until that).
+
+  // we are creating a mapping so that ANY OF THESE 4 SYNTAXES would be honored.
+  // So, authors can use links that refer to physical files, and gatsby will render a link that works - the same link
+  // can work on github and gatsby
+
+  // note that often, the physical location and the slug are the same!
+  // However there is no guarantee that this will be the case.
+
+  const relativeToCurrentFile = path.relative(
+    edge.node.fileAbsolutePath,
+    source
+  );
+  const relativeToRootFolder = path.relative(rootFolder, source);
+  const relativeToCurrentSlug = path.relative(edge.node.fields.path, target);
+
+  const absoluteTarget = `/${target}`;
+
+  return {
+    ...relativeLinks,
+    [relativeToCurrentFile]: absoluteTarget,
+    [relativeToCurrentFile]: absoluteTarget,
+    [relativeToRootFolder]: absoluteTarget,
+    [relativeToCurrentSlug]: absoluteTarget,
+    [target]: absoluteTarget
+  };
+}
+
 // Walks all markdown nodes and creates a doc page for each node
 function createDocPages({ graphql, actions }) {
   const { createPage } = actions;
@@ -175,49 +223,16 @@ function createDocPages({ graphql, actions }) {
         categorySet.add(edge.node.frontmatter.category);
       }
 
-      const relativeLinks = pathToSlug.reduce((prev, { source, target }) => {
-        // what we are doing here: for each markdown file, we create a mapping of different ways to
-        // link to another markdown file that we will honor.
-
-        // let's suppose that we want to go from a file:
-        // - physical location: /docs/my-files/source.md, slug: /docs/chapter-1/source
-        // to this file:
-        // - phyiscal location: /docs/developer-guide/target.md, slug: /docs/advanced-usage/api-reference/target
-
-        // by default, '../../advanced-usage/api/reference/target' would work (target file slug, relative to original slug)
-        // '/docs/advanced-usage/api-reference/target' would also work (absolute target slug)
-        // however, on github, those links wouldn't work as there is no phyiscal file behind that link.
-        // in github however: '/docs/developer-guide/target.md' (file name relative to root) or
-        // '../developer-guide/target.md' (relative file name) would work. Those links wouldn't work on the gatsby rendered
-        // page however (until that).
-
-        // we are creating a mapping so that ANY OF THESE 4 SYNTAXES would be honored.
-        // So, authors can use links that refer to physical files, and gatsby will render a link that works - the same link
-        // can work on github and gatsby
-
-        // note that often, the physical location and the slug are the same!
-        // However there is no guarantee that this will be the case.
-
-        const relativeToCurrentFile = path.relative(
-          edge.node.fileAbsolutePath,
-          source
-        );
-        const relativeToRootFolder = path.relative(rootFolder, source);
-        const relativeToCurrentSlug = path.relative(
-          edge.node.fields.path,
-          target
-        );
-
-        const absoluteTarget = `/${target}`;
-
-        return {
-          ...prev,
-          [relativeToCurrentFile]: absoluteTarget,
-          [relativeToRootFolder]: absoluteTarget,
-          [relativeToCurrentSlug]: absoluteTarget,
-          [target]: absoluteTarget
-        };
-      }, {});
+      let relativeLinks = {};
+      pathToSlug.forEach(({ source, target }) => {
+        relativeLinks = addToRelativeLinks({
+          source,
+          target,
+          rootFolder,
+          edge,
+          relativeLinks
+        });
+      });
 
       // console.log('Creating doc page at', edge.node.fields.path);
 

--- a/modules/gatsby/src/templates/doc-n.jsx
+++ b/modules/gatsby/src/templates/doc-n.jsx
@@ -1,7 +1,6 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from 'react';
 
-import { graphql } from 'gatsby'
+import { graphql } from 'gatsby';
 
 // Query for the markdown doc by slug
 // (Note: We could just search the allMarkdown from WebsiteConfig ourselves)
@@ -21,19 +20,37 @@ export const query = graphql`
   }
 `;
 
+function replaceLinks(props) {
+  const { html } = props.data.docBySlug;
+  const { relativeLinks } = props.pageContext;
+
+  return html.replace(/href="([^"]+)"/g, (link, href) => {
+    // don't rewrite external links, don't rewrite links to anchors
+    if (href.startsWith('http') || href.startsWith('#')) {
+      // TODO - we could style them differently though
+      return link;
+    }
+    const hrefWithoutLeadingSlash = href.startsWith('/') ? href.slice(1) : href;
+    // replace links to:
+    // - known physical files, either relative to this file or relative to root
+    // - known routes, either relative to the route of this page or to the home page
+    // by a link to their corresponding route, expresed relative to the home page
+    return `href="${relativeLinks[hrefWithoutLeadingSlash]}"`;
+  });
+}
+
 export default class DocTemplate extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { html: replaceLinks(props) };
+  }
+
   render() {
-    const {data, pathContext} = this.props;
-    const { slug } = pathContext
-    const docNode = data.docBySlug
-    const doc = docNode.frontmatter
-    // if (!doc.id) {
-    //   doc.id = slug
-    // }
+    const { html } = this.state;
     return (
       <div>
-        <div dangerouslySetInnerHTML={{ __html: docNode.html }} />
+        <div dangerouslySetInnerHTML={{ __html: html }} />
       </div>
-    )
+    );
   }
 }

--- a/modules/gatsby/yarn.lock
+++ b/modules/gatsby/yarn.lock
@@ -5932,10 +5932,6 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://unpm.uberinternal.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-
 rxjs@^6.1.0:
   version "6.3.3"
   resolved "https://unpm.uberinternal.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"


### PR DESCRIPTION
This PR allows docs authors to use "physical" links (ie from markdown file to markdown file, written in a syntax compatible w/ gitHub conventions) and have them rendered by gatsby as a link from a route to another route.

