### PR TITLE
Remove puppeteer from dev-tools dependency

### DIFF
--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "puppeteer": "^1.11.0",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",


### PR DESCRIPTION
`puppeteer` version is locked by `@probe.gl/test-utils`