### PR TITLE
Examples homepage

### DIFF
--- a/modules/gatsby/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby/src/gatsby-config/get-gatsby-config.js
@@ -75,7 +75,14 @@ module.exports = function getGatsbyConfig(config) {
           path: `${__dirname}/../../static/`
         }
       },
-      // Generates gatsby nodes for files in the website's static folder
+      // Generates gatsby nodes for files in the website's src folder
+      {
+        resolve: 'gatsby-source-filesystem',
+        options: {
+          name: 'src',
+          path: `${config.DIR_NAME}/src/`
+        }
+      },
       // Generates gatsby nodes for files in the website's static folder
       {
         resolve: 'gatsby-source-filesystem',

--- a/modules/gatsby/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby/src/gatsby-config/get-gatsby-config.js
@@ -79,14 +79,7 @@ module.exports = function getGatsbyConfig(config) {
           path: `${__dirname}/../../static/`
         }
       },
-      // Generates gatsby nodes for files in the website's src folder
-      {
-        resolve: 'gatsby-source-filesystem',
-        options: {
-          name: 'src',
-          path: `${config.DIR_NAME}/src/`
-        }
-      },
+      
       // Generates gatsby nodes for files in the website's static folder
       {
         resolve: 'gatsby-source-filesystem',
@@ -319,6 +312,19 @@ module.exports = function getGatsbyConfig(config) {
       */
     ]
   };
+
+  // conditional plug-ins - only added depending on options on config
+
+  if (config.DIR_NAME) {
+    // Generates gatsby nodes for files in the website's src folder
+    gatsbyConfig.plugins.push({
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'src',
+        path: `${config.DIR_NAME}/src/`
+      }
+    });
+  }
 
   // log.log({color: COLOR.CYAN}, `GATSBY CONFIG ${JSON.stringify(gatsbyConfig, null, 3)}`)();
   return gatsbyConfig;

--- a/modules/gatsby/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby/src/gatsby-config/get-gatsby-config.js
@@ -1,20 +1,22 @@
 const urljoin = require('url-join');
 
-const {log, COLOR} = require('../utils/log');
+const { log, COLOR } = require('../utils/log');
 
 module.exports = function getGatsbyConfig(config) {
-  const {logLevel = 0} = config;
+  const { logLevel = 0 } = config;
   log.priority = logLevel;
 
-  log.log({color: COLOR.CYAN, priority: 0}, 'Loading gatsby config')();
-  log.log({color: COLOR.CYAN, priority: 2}, `GATSBY CONFIG ${JSON.stringify(config, null, 3)}`)();
+  log.log({ color: COLOR.CYAN, priority: 0 }, 'Loading gatsby config')();
+  log.log(
+    { color: COLOR.CYAN, priority: 2 },
+    `GATSBY CONFIG ${JSON.stringify(config, null, 3)}`
+  )();
 
   // Entry cannot be empty, since graphql then cannot autoinfer schemas
   // which means queries will fail (sigh...)
   if (!config.EXAMPLES || config.EXAMPLES.length === 0) {
-    config.EXAMPLES = [{title: 'none', path: 'none'}];
+    config.EXAMPLES = [{ title: 'none', path: 'none' }];
   }
-
 
   const gatsbyConfig = {
     pathPrefix: config.pathPrefix,
@@ -31,7 +33,8 @@ module.exports = function getGatsbyConfig(config) {
         image_url: urljoin(
           config.siteUrl,
           config.pathPrefix,
-          '/logos/logo-512.png'),
+          '/logos/logo-512.png'
+        ),
         author: config.userName,
         copyright: config.copyright
       }
@@ -43,10 +46,11 @@ module.exports = function getGatsbyConfig(config) {
 
       // A Gatsby plugin for styled-components with built-in server-side rendering support.
       'gatsby-plugin-styled-components',
-
+      'gatsby-plugin-sharp',
+      'gatsby-transformer-sharp',
       // Drop-in support for SASS/SCSS stylesheets
       {
-        resolve: `gatsby-plugin-sass`,
+        resolve: `gatsby-plugin-sass`
         /*
         options: {
           includePaths: [
@@ -194,12 +198,12 @@ module.exports = function getGatsbyConfig(config) {
 
       // Transforms JSON files in the data source into JSON nodes
       {
-        resolve: `gatsby-transformer-json`,
+        resolve: `gatsby-transformer-json`
         // options: {
         //   typeName: ({ node, object, isArray }) =>
         //     console.log('json', node, object, isArray) && object.level,
         // },
-      },
+      }
 
       /*
       // Gatsby’s manifest plugin creates a manifest.webmanifest file on every build.
@@ -318,4 +322,4 @@ module.exports = function getGatsbyConfig(config) {
 
   // log.log({color: COLOR.CYAN}, `GATSBY CONFIG ${JSON.stringify(gatsbyConfig, null, 3)}`)();
   return gatsbyConfig;
-}
+};

--- a/modules/gatsby/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby/src/gatsby-config/get-gatsby-config.js
@@ -324,6 +324,8 @@ module.exports = function getGatsbyConfig(config) {
         path: `${config.DIR_NAME}/src/`
       }
     });
+  } else {
+    log.log({ color: COLOR.YELLOW }, `DIR_NAME not found in ocular-gatsby config}`)();
   }
 
   // log.log({color: COLOR.CYAN}, `GATSBY CONFIG ${JSON.stringify(gatsbyConfig, null, 3)}`)();

--- a/modules/gatsby/src/gatsby-node/create-example-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-example-pages.js
@@ -1,0 +1,160 @@
+const path = require('path');
+const { log, COLOR } = require('../utils/log');
+
+const EXAMPLES_PAGE = path.resolve(__dirname, '../templates/examples.jsx');
+const EXAMPLE_PAGE = path.resolve(__dirname, '../templates/example-n.jsx');
+
+function getExampleThumbnails({ allFile, allImageSharp }) {
+  // this function associates the path of an original image
+  // with the public url of a thumbnail, resized server side by imageSharp.
+  if (
+    !allFile ||
+    !allFile.edges ||
+    !allFile.edges.length ||
+    !allImageSharp ||
+    !allImageSharp.edges ||
+    !allImageSharp.edges.length
+  ) {
+    log.log({ color: COLOR.YELLOW, priority: 1 }, `No thumbnails created.`)();
+    return {};
+  }
+  // in a first pass, we create a lookup - original path to internal gatsby node id.
+  /* eslint-disable no-param-reassign */
+  const idLookup = allFile.edges.reduce((lookup, { node }) => {
+    lookup[node.id] = node.relativePath;
+    return lookup;
+  }, {});
+
+  // in a second path, we associate each thumbnail with the path of the original
+  // image, using the node id of this original image and the lookup
+  // we just created.
+
+  const pathLookup = allImageSharp.edges.reduce((lookup, { node }) => {
+    const originalImageId = node.parent.id;
+    const originalImagePath = idLookup[originalImageId];
+    lookup[originalImagePath] = node.resize.src;
+    return lookup;
+  }, {});
+
+  /* eslint-enable no-param-reassign */
+  return pathLookup;
+}
+
+function createExamplePages(EXAMPLES, thumbnailsPublicUrls = {}, createPage) {
+  if (EXAMPLES.length === 0 || EXAMPLES[0].title === 'none') {
+    return;
+  }
+  // matches public urls to paths of images
+  const examplesWithImage = EXAMPLES.map(example => ({
+    ...example,
+    imageSrc: thumbnailsPublicUrls[example.image]
+  }));
+
+  createPage({
+    component: EXAMPLES_PAGE,
+    path: '/examples',
+    context: {
+      toc: 'examples',
+      examples: examplesWithImage
+    }
+  });
+
+  EXAMPLES.forEach(example => {
+    const exampleName = example.title;
+
+    log.log(
+      { color: COLOR.CYAN, priority: 1 },
+      `Creating example page ${JSON.stringify(example)}`
+    )();
+
+    createPage({
+      path: example.path,
+      component: EXAMPLE_PAGE,
+      context: {
+        slug: exampleName,
+        toc: 'examples'
+      }
+    });
+  });
+}
+
+module.exports = function prepareExamplePages({ graphql, actions }) {
+  const { createPage } = actions;
+  return graphql(`
+    {
+      site {
+        siteMetadata {
+          config {
+            EXAMPLES {
+              image
+              title
+              path
+            }
+          }
+        }
+      }
+      allImageSharp {
+        edges {
+          node {
+            parent {
+              id
+            }
+            resize(width: 150, height: 150) {
+              src
+            }
+          }
+        }
+      }
+      allFile {
+        edges {
+          node {
+            id
+            relativePath
+          }
+        }
+      }
+    }
+  `)
+    .then(result => {
+      console.log(result);
+
+      if (result.errors) {
+        /* eslint no-console: "off" */
+        console.log(result.errors);
+        throw new Error(result.errors);
+      }
+      const { EXAMPLES } = result.data.site.siteMetadata.config;
+      // build a lookup map that matches relative paths of images with their public URLs
+      const thumbnailsPublicUrls = getExampleThumbnails(result.data);
+      // If the no examples marker, return without creating pages
+      createExamplePages(EXAMPLES, thumbnailsPublicUrls, createPage);
+    })
+    .catch(error => {
+      log.log(
+        { color: COLOR.BRIGHT_YELLOW },
+        `error in createPage query with images: ${error}`
+      )();
+      return graphql(`
+        {
+          site {
+            siteMetadata {
+              config {
+                EXAMPLES {
+                  title
+                  path
+                }
+              }
+            }
+          }
+        }
+      `).then(result => {
+        if (result.errors) {
+          /* eslint no-console: "off" */
+          console.log(result.errors);
+          throw new Error(result.errors);
+        }
+        const { EXAMPLES } = result.data.site.siteMetadata.config;
+        createExamplePages(EXAMPLES, {}, createPage);
+      });
+    });
+};

--- a/modules/gatsby/src/gatsby-node/create-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-pages.js
@@ -2,13 +2,12 @@ const path = require('path');
 const assert = require('assert');
 
 const { log, COLOR } = require('../utils/log');
-
+const prepareExamplePages = require('./create-example-pages');
 // PATHS TO REACT PAGES
 const INDEX_PAGE = path.resolve(__dirname, '../templates/index.jsx');
 const SEARCH_PAGE = path.resolve(__dirname, '../templates/search.jsx');
 
 const DOC_PAGE = path.resolve(__dirname, '../templates/doc-n.jsx');
-
 const EXAMPLES_PAGE = path.resolve(__dirname, '../templates/examples.jsx');
 const EXAMPLE_PAGE = path.resolve(__dirname, '../templates/example-n.jsx');
 
@@ -65,128 +64,6 @@ function createSearchPage({ graphql, actions }) {
       }
     })
   );
-}
-
-function getExampleThumbnails({ allFile, allImageSharp }) {
-  // this function associates the path of an original image
-  // with the public url of a thumbnail, resized server side by imageSharp.
-  if (
-    !allFile ||
-    !allFile.edges ||
-    !allFile.edges.length ||
-    !allImageSharp ||
-    !allImageSharp.edges ||
-    !allImageSharp.edges.length
-  ) {
-    return {};
-  }
-  // in a first pass, we create a lookup - original path to internal gatsby node id.
-  /* eslint-disable no-param-reassign */
-  const idLookup = allFile.edges.reduce((lookup, { node }) => {
-    lookup[node.id] = node.relativePath;
-    return lookup;
-  }, {});
-
-  // in a second path, we associate each thumbnail with the path of the original
-  // image, using the node id of this original image and the lookup
-  // we just created.
-
-  const pathLookup = allImageSharp.edges.reduce((lookup, { node }) => {
-    const originalImageId = node.parent.id;
-    const originalImagePath = idLookup[originalImageId];
-    lookup[originalImagePath] = node.resize.src;
-    return lookup;
-  }, {});
-
-  /* eslint-enable no-param-reassign */
-  return pathLookup;
-}
-
-function createExamplePages({ graphql, actions }) {
-  const { createPage } = actions;
-
-  return graphql(`
-    {
-      site {
-        siteMetadata {
-          config {
-            EXAMPLES {
-              image
-              title
-              path
-            }
-          }
-        }
-      }
-      allImageSharp {
-        edges {
-          node {
-            parent {
-              id
-            }
-            resize(width: 150, height: 150) {
-              src
-            }
-          }
-        }
-      }
-      allFile {
-        edges {
-          node {
-            id
-            relativePath
-          }
-        }
-      }
-    }
-  `).then(result => {
-    console.log(result);
-
-    if (result.errors) {
-      /* eslint no-console: "off" */
-      console.log(result.errors);
-      throw new Error(result.errors);
-    }
-    const { EXAMPLES } = result.data.site.siteMetadata.config;
-    // build a lookup map that matches relative paths of images with their public URLs
-    const thumbnailsPublicUrls = getExampleThumbnails(result.data);
-    // If the no examples marker, return without creating pages
-    if (EXAMPLES.length === 0 || EXAMPLES[0].title === 'none') {
-      return;
-    }
-    // matches public urls to paths of images
-    const examplesWithImage = EXAMPLES.map(example => ({
-      ...example,
-      imageSrc: thumbnailsPublicUrls[example.image]
-    }));
-
-    createPage({
-      component: EXAMPLES_PAGE,
-      path: '/examples',
-      context: {
-        toc: 'examples',
-        examples: examplesWithImage
-      }
-    });
-
-    for (const example of EXAMPLES) {
-      const exampleName = example.title;
-
-      log.log(
-        { color: COLOR.CYAN, priority: 1 },
-        `Creating example page ${JSON.stringify(example)}`
-      )();
-
-      createPage({
-        path: example.path,
-        component: EXAMPLE_PAGE,
-        context: {
-          slug: exampleName,
-          toc: 'examples'
-        }
-      });
-    }
-  });
 }
 
 function addToRelativeLinks({
@@ -342,7 +219,7 @@ module.exports = function createPages({ graphql, actions }, pluginOptions) {
 
   let examplesPromise;
   if (examplePages) {
-    examplesPromise = createExamplePages({ graphql, actions });
+    examplesPromise = prepareExamplePages({ graphql, actions });
   }
 
   let searchPromise;

--- a/modules/gatsby/src/gatsby-node/create-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-pages.js
@@ -76,9 +76,18 @@ function createExamplePages({ graphql, actions }) {
         siteMetadata {
           config {
             EXAMPLES {
+              image
               title
               path
             }
+          }
+        }
+      }
+      allFile {
+        edges {
+          node {
+            relativePath
+            publicURL
           }
         }
       }
@@ -91,19 +100,34 @@ function createExamplePages({ graphql, actions }) {
       console.log(result.errors);
       throw new Error(result.errors);
     }
-
     const { EXAMPLES } = result.data.site.siteMetadata.config;
+    // build a lookup map that matches relative paths of images with their public URLs
+    const imagesPublicUrls = result.data.allFile.edges.reduce(
+      (hash, { node }) => {
+        /* eslint-disable no-param-reassign */
+        hash[node.relativePath] = node.publicURL;
+        /* eslint-enable no-param-reassign */
+        return hash;
+      },
+      {}
+    );
 
     // If the no examples marker, return without creating pages
     if (EXAMPLES.length === 0 || EXAMPLES[0].title === 'none') {
       return;
     }
+    // matches public urls to paths of images
+    const examplesWithImage = EXAMPLES.map(example => ({
+      ...example,
+      imageSrc: imagesPublicUrls[example.image]
+    }));
 
     createPage({
       component: EXAMPLES_PAGE,
       path: '/examples',
       context: {
-        toc: 'examples'
+        toc: 'examples',
+        examples: examplesWithImage
       }
     });
 

--- a/modules/gatsby/src/templates/example-n.jsx
+++ b/modules/gatsby/src/templates/example-n.jsx
@@ -33,7 +33,7 @@ const Main = styled.main`
 
 export default class ExampleTemplate extends React.Component {
   render() {
-    const { pathContext } = this.props;
+    const { pathContext, pageResources } = this.props;
     const { slug } = pathContext;
 
     // Get app website's example runner
@@ -55,7 +55,7 @@ export default class ExampleTemplate extends React.Component {
               <DemoRunner
                 height={height}
                 example={example}
-                sourceLink={example.path}
+                sourceLink={pageResources && pageResources.page && pageResources.page.path}
                 width={width}
               />
             )

--- a/modules/gatsby/src/templates/examples.jsx
+++ b/modules/gatsby/src/templates/examples.jsx
@@ -75,7 +75,9 @@ export default class Examples extends Component {
         {examples.map(exampleData => (
           <ExampleCard>
             <Link to={exampleData.path}>
-              <img src={exampleData.imageSrc} alt={exampleData.title} />
+              {exampleData.imageSrc ? (
+                <img src={exampleData.imageSrc} alt={exampleData.title} />
+              ) : null}
               <ExampleTitle>{exampleData.title}</ExampleTitle>
             </Link>
           </ExampleCard>

--- a/modules/gatsby/src/templates/examples.jsx
+++ b/modules/gatsby/src/templates/examples.jsx
@@ -6,24 +6,42 @@ import { graphql } from 'gatsby';
 
 import ExampleTableOfContents from '../components/layout/example-table-of-contents';
 
-const Gallery = styled.main`
+const colors = {
+  black: '#000',
+  gray6: '#f6f6f6',
+  white: '#fff'
+};
+
+const Main = styled.main`
+  background: ${colors.white};
   display: flex;
   flex-wrap: wrap;
-  height: calc(100vh - 96px);
   @media screen and (max-width: 600px) {
     margin-top: 64px;
   }
 `;
 
 const ExampleCard = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid #f7f7f7;
-  border-radius: 4px;
-  width: 180px;
-  height: 180px;
+  border: 1px solid ${colors.gray6};
+  cursor: pointer;
   margin: 10px;
+  padding: 20px 16px;
+  transition: background 0.3s border-color 0.3s;
+  &:hover {
+    background: ${colors.gray6};
+    border-color: transparent;
+  }
+`;
+
+const ExampleTitle = styled.div`
+  color: ${colors.black};
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 150px;
 `;
 
 /* eslint no-undef: "off" */
@@ -49,18 +67,20 @@ class Gallery extends Component {
 
 export default class Examples extends Component {
   render() {
-    const { examples } = this.props.pageContext;
+    const {
+      pageContext: { examples }
+    } = this.props;
     return (
-      <Gallery>
+      <Main>
         {examples.map(exampleData => (
           <ExampleCard>
             <Link to={exampleData.path}>
-              <img src={exampleData.imageSrc} height={150} width={150} />
-              {exampleData.title}
+              <img src={exampleData.imageSrc} alt={exampleData.title} />
+              <ExampleTitle>{exampleData.title}</ExampleTitle>
             </Link>
           </ExampleCard>
         ))}
-      </Gallery>
+      </Main>
     );
   }
 }

--- a/modules/gatsby/src/templates/examples.jsx
+++ b/modules/gatsby/src/templates/examples.jsx
@@ -1,9 +1,30 @@
-import React, {Component} from 'react'
-import styled from 'styled-components'
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import { Link } from 'gatsby';
 
 import { graphql } from 'gatsby';
 
-import ExampleTableOfContents from '../components/layout/example-table-of-contents'
+import ExampleTableOfContents from '../components/layout/example-table-of-contents';
+
+const Gallery = styled.main`
+  display: flex;
+  flex-wrap: wrap;
+  height: calc(100vh - 96px);
+  @media screen and (max-width: 600px) {
+    margin-top: 64px;
+  }
+`;
+
+const ExampleCard = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid #f7f7f7;
+  border-radius: 4px;
+  width: 180px;
+  height: 180px;
+  margin: 10px;
+`;
 
 /* eslint no-undef: "off" */
 
@@ -28,11 +49,18 @@ class Gallery extends Component {
 
 export default class Examples extends Component {
   render() {
+    const { examples } = this.props.pageContext;
     return (
-      <main>
-        { // TODO/ib Add example thumbnail gallery <Gallery />
-        }
-      </main>
+      <Gallery>
+        {examples.map(exampleData => (
+          <ExampleCard>
+            <Link to={exampleData.path}>
+              <img src={exampleData.imageSrc} height={150} width={150} />
+              {exampleData.title}
+            </Link>
+          </ExampleCard>
+        ))}
+      </Gallery>
     );
   }
 }


### PR DESCRIPTION
This PR addresses
- creation of an examples gallery page,
- generation of image thumbnails for the purpose of this gallery,
- fix to example runner to provide sourceLink when needed (which crashed example when external files had to be loaded)
- slght change to ocular config template to add DIR_NAME to config 