### PR TITLE
Styling through styled components

### DIFF
--- a/modules/gatsby/src/components/layout/layout.js
+++ b/modules/gatsby/src/components/layout/layout.js
@@ -4,7 +4,8 @@
 
 import React from 'react'
 import Helmet from 'react-helmet'
-import styled from 'styled-components'
+import { lightThemePrimitives, createTheme } from '../styled/theme';
+
 import {StaticQuery, graphql} from 'gatsby'
 
 import TopLevelLayout from './top-level-layout';
@@ -107,12 +108,21 @@ export default class Layout extends React.Component {
 
     // console.log('StaticQuery result', config, tableOfContents, allMarkdown);
 
+    const themeFromConfig = (
+      (this.props.value &&
+        this.props.value.config &&
+        this.props.value.config.THEME_OVERIDES) ||
+      []
+    ).reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {});
+
+    const theme = createTheme({ ...lightThemePrimitives, ...themeFromConfig });
+
     return (
       <TopLevelLayout {...this.props}
         config={config}
         tableOfContents={tableOfContents}
-        allMarkdown={allMarkdown} >
-
+        allMarkdown={allMarkdown}
+        theme={theme} >
         { children }
 
       </TopLevelLayout>

--- a/modules/gatsby/src/components/layout/top-level-layout.jsx
+++ b/modules/gatsby/src/components/layout/top-level-layout.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import MediaQuery from 'react-responsive';
-import theme from '../styled/theme';
 
 import { WebsiteConfigProvider } from './website-config';
 
@@ -49,7 +48,7 @@ export default class Layout extends React.Component {
   }
 
   renderBodyWithTOC(config, tableOfContents) {
-    const { children, pathContext } = this.props;
+    const { children, pathContext, theme } = this.props;
     const { isMenuOpen } = this.state;
     const isExample = pathContext.toc === 'examples';
     return (
@@ -72,7 +71,7 @@ export default class Layout extends React.Component {
   }
 
   renderBodyFull(config) {
-    const { children } = this.props;
+    const { children, theme } = this.props;
     const { isMenuOpen } = this.state;
 
     return (
@@ -99,7 +98,7 @@ export default class Layout extends React.Component {
   }
 
   renderTOC(config, tableOfContents) {
-    const { pageContext } = this.props;
+    const { pageContext, theme } = this.props;
     switch (pageContext.toc) {
       case 'docs':
         return (
@@ -150,9 +149,8 @@ export default class Layout extends React.Component {
     // Since gatsby's StaticQueries can't run in a plugin, we rely on the app website's
     // Layout wrapper component to query for us and pass in the data.
     const { pageContext, config, theme, tableOfContents, allMarkdown } = this.props;
-    console.log(theme);
     return (
-      <WebsiteConfigProvider value={{ config, tableOfContents, allMarkdown }}>
+      <WebsiteConfigProvider value={{ config, theme, tableOfContents, allMarkdown }}>
         <div>
           {allMarkdown ? (
             <SEO postEdges={allMarkdown} />

--- a/modules/gatsby/src/components/layout/top-level-layout.jsx
+++ b/modules/gatsby/src/components/layout/top-level-layout.jsx
@@ -4,8 +4,8 @@
 
 import React from 'react';
 import Helmet from 'react-helmet';
-import styled from 'styled-components';
 import MediaQuery from 'react-responsive';
+import theme from '../styled/theme';
 
 import { WebsiteConfigProvider } from './website-config';
 
@@ -14,63 +14,17 @@ import SEO from '../common/SEO';
 import TableOfContents from './table-of-contents';
 import ExampleTableOfContents from './example-table-of-contents';
 import Header from './header';
+
+import {
+  ToCContainer,
+  BodyGrid,
+  HeaderContainer,
+  BodyContainerFull,
+  BodyContainerToC
+} from '../styled';
+
 // TODO/ib - restore footer
 // import Footer from './footer';
-
-const BodyGrid = styled.div`
-  height: 100vh;
-  display: grid;
-  grid-template-rows: 64px 1fr;
-  grid-template-columns: 300px 1fr;
-
-  @media screen and (max-width: 600px) {
-    display: flex;
-    flex-direction: column;
-    height: inherit;
-  }
-`;
-
-const HeaderContainer = styled.div`
-  grid-column: 1 / 3;
-  grid-row: 1 / 2;
-  z-index: 2;
-  @media screen and (max-width: 600px) {
-    order: 1;
-  }
-`;
-
-const BodyContainerFull = styled.div`
-  padding: ${props => props.theme.sitePadding};
-  max-width: ${props => props.theme.contentWidthLaptop};
-  margin: 0 auto;
-
-  .contributors {
-    max-width: 400px;
-    margin: 100px auto 0;
-  }
-`;
-const BodyContainerToC = styled.div`
-  grid-column: 2 / 3;
-  grid-row: 2 / 3;
-  width: 100%;
-  max-width: ${props => (props.isExample ? null : '600px')};
-  padding: 12px;
-  @media screen and (max-width: 600px) {
-    order: 2;
-  }
-
-  & > div {
-    max-width: ${props => props.theme.contentWidthLaptop};
-    margin: auto;
-  }
-  & p {
-    margin-bottom: 1em;
-  }
-
-  & > h1 {
-    color: ${props => props.theme.accentDark};
-  }
-`;
 
 function ResponsiveHeader(props) {
   return (
@@ -85,17 +39,6 @@ function ResponsiveHeader(props) {
   );
 }
 
-const ToCContainer = styled.div`
-  grid-column: 1 / 2;
-  grid-row: 2 / 3;
-  background: ${props => props.theme.lightGrey};
-  overflow: scroll;
-  @media screen and (max-width: 600px) {
-    order: 3;
-    overflow: inherit;
-  }
-`;
-
 export default class Layout extends React.Component {
   constructor(props) {
     super(props);
@@ -103,6 +46,56 @@ export default class Layout extends React.Component {
       isMenuOpen: false
     };
     this.toggleMenu = this.toggleMenu.bind(this);
+  }
+
+  renderBodyWithTOC(config, tableOfContents) {
+    const { children, pathContext } = this.props;
+    const { isMenuOpen } = this.state;
+    const isExample = pathContext.toc === 'examples';
+    return (
+      <BodyGrid theme={theme}>
+        <HeaderContainer theme={theme}>
+          <ResponsiveHeader
+            config={config}
+            isMenuOpen={isMenuOpen}
+            toggleMenu={this.toggleMenu}
+          />
+        </HeaderContainer>
+
+        <ToCContainer theme={theme}>{this.renderTOC(config, tableOfContents)}</ToCContainer>
+
+        <BodyContainerToC isExample={isExample} theme={theme}>{children}</BodyContainerToC>
+
+        {/* <Footer /> */}
+      </BodyGrid>
+    );
+  }
+
+  renderBodyFull(config) {
+    const { children } = this.props;
+    const { isMenuOpen } = this.state;
+
+    return (
+      <div>
+        <HeaderContainer theme={theme}>
+          <ResponsiveHeader
+            config={config}
+            isMenuOpen={isMenuOpen}
+            theme={theme}
+            toggleMenu={this.toggleMenu}
+          />
+        </HeaderContainer>
+
+        <BodyContainerFull theme={theme}>{children}</BodyContainerFull>
+
+        {/* <Footer /> */}
+      </div>
+    );
+  }
+
+  toggleMenu() {
+    const { isMenuOpen } = this.state;
+    this.setState({ isMenuOpen: !isMenuOpen });
   }
 
   renderTOC(config, tableOfContents) {
@@ -113,6 +106,7 @@ export default class Layout extends React.Component {
           <TableOfContents
             chapters={tableOfContents.chapters}
             slug={pageContext.slug}
+            theme={theme}
           />
         );
 
@@ -152,59 +146,11 @@ export default class Layout extends React.Component {
     }
   }
 
-  renderBodyWithTOC(config, tableOfContents) {
-    const { children, pathContext } = this.props;
-    const { isMenuOpen } = this.state;
-    const isExample = pathContext.toc === 'examples';
-    return (
-      <BodyGrid>
-        <HeaderContainer>
-          <ResponsiveHeader
-            config={config}
-            isMenuOpen={isMenuOpen}
-            toggleMenu={this.toggleMenu}
-          />
-        </HeaderContainer>
-
-        <ToCContainer>{this.renderTOC(config, tableOfContents)}</ToCContainer>
-
-        <BodyContainerToC isExample={isExample}>{children}</BodyContainerToC>
-
-        {/* <Footer /> */}
-      </BodyGrid>
-    );
-  }
-
-  renderBodyFull(config) {
-    const { children } = this.props;
-    const { isMenuOpen } = this.state;
-
-    return (
-      <div>
-        <HeaderContainer>
-          <ResponsiveHeader
-            config={config}
-            isMenuOpen={isMenuOpen}
-            toggleMenu={this.toggleMenu}
-          />
-        </HeaderContainer>
-
-        <BodyContainerFull>{children}</BodyContainerFull>
-
-        {/* <Footer /> */}
-      </div>
-    );
-  }
-
-  toggleMenu() {
-    const { isMenuOpen } = this.state;
-    this.setState({ isMenuOpen: !isMenuOpen });
-  }
-
   render() {
     // Since gatsby's StaticQueries can't run in a plugin, we rely on the app website's
     // Layout wrapper component to query for us and pass in the data.
-    const { pageContext, config, tableOfContents, allMarkdown } = this.props;
+    const { pageContext, config, theme, tableOfContents, allMarkdown } = this.props;
+    console.log(theme);
     return (
       <WebsiteConfigProvider value={{ config, tableOfContents, allMarkdown }}>
         <div>

--- a/modules/gatsby/src/components/layout/website-config.jsx
+++ b/modules/gatsby/src/components/layout/website-config.jsx
@@ -3,7 +3,8 @@
 // https://www.gatsbyjs.org/packages/gatsby-plugin-layout/
 
 // Context.js
-import React from "react";
+import React from 'react';
+import { lightThemePrimitives, createTheme } from '../styled/theme';
 
 const defaultContextValue = {
   initialized: false,
@@ -20,10 +21,18 @@ const { Provider, Consumer } = React.createContext(defaultContextValue);
 export class WebsiteConfigProvider extends React.Component {
   constructor(props) {
     super(props);
-
+    const themeFromConfig = (
+      (props.value &&
+        props.value.config &&
+        props.value.config.THEME_OVERIDES) ||
+      []
+    ).reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {});
+    
+    const theme = createTheme({ ...lightThemePrimitives, ...themeFromConfig });
     this.setData = this.setData.bind(this);
     this.state = {
       ...defaultContextValue,
+      ...theme,
       ...props.value,
       set: this.setData
     };

--- a/modules/gatsby/src/components/layout/website-config.jsx
+++ b/modules/gatsby/src/components/layout/website-config.jsx
@@ -4,13 +4,12 @@
 
 // Context.js
 import React from 'react';
-import { lightThemePrimitives, createTheme } from '../styled/theme';
 
 const defaultContextValue = {
   initialized: false,
   config: {},
   tableOfContents: null,
-
+  theme: {},
   // For passing data upwards
   data: {},
   set: () => {}
@@ -21,18 +20,10 @@ const { Provider, Consumer } = React.createContext(defaultContextValue);
 export class WebsiteConfigProvider extends React.Component {
   constructor(props) {
     super(props);
-    const themeFromConfig = (
-      (props.value &&
-        props.value.config &&
-        props.value.config.THEME_OVERIDES) ||
-      []
-    ).reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {});
-    
-    const theme = createTheme({ ...lightThemePrimitives, ...themeFromConfig });
+
     this.setData = this.setData.bind(this);
     this.state = {
       ...defaultContextValue,
-      ...theme,
       ...props.value,
       set: this.setData
     };

--- a/modules/gatsby/src/components/styled/index.js
+++ b/modules/gatsby/src/components/styled/index.js
@@ -1,0 +1,157 @@
+import styled from 'styled-components';
+import theme from './theme';
+/* eslint-disable import/prefer-default-export */
+
+// top-level layoout
+
+export const BodyContainerFull = styled.div(props => ({
+  padding: props.theme.sizing.scale400,
+  maxWidth: props.theme.breakpoints.large,
+  margin: '0 auto',
+
+  '.contributors': {
+    maxWidth: '400px',
+    margin: '100px auto 0'
+  }
+}));
+
+export const BodyContainerToC = styled.div(props => ({
+  gridColumn: '2 / 3',
+  gridRow: '2 / 3',
+  width: '100%',
+  maxWidth: props.isExample ? null : props.theme.breakpoints.medium,
+  padding: props.theme.sizing.scale500,
+  [`@media screen and (max-width: ${props.theme.breakpoints.medium})`]: {
+    order: 2
+  },
+
+  '& > div': {
+    maxWidth: props.theme.breakpoints.large,
+    margin: 'auto'
+  },
+  '& p': {
+    marginBottom: props.theme.sizing.scale500
+  },
+
+  '& > h1': {
+    color: theme.colors.mono1000
+  }
+}));
+
+export const BodyGrid = styled.div`
+  height: 100vh;
+  display: grid;
+  grid-template-rows: 64px 1fr;
+  grid-template-columns: 300px 1fr;
+
+  @media screen and (max-width: ${theme.breakpoints.medium}) {
+    display: flex;
+    flex-direction: column;
+    height: inherit;
+  }
+`;
+
+export const HeaderContainer = styled.div(props => ({
+  gridColumn: '1 / 3',
+  gridRow: '1 / 2',
+  zIndex: 2,
+  [`@media screen and (max-width: ${props.theme.breakpoints.medium})`]: {
+    order: 1
+  }
+}));
+
+export const ToCContainer = styled.div(props => ({
+  gridColumn: '1 / 2',
+  gridRow: '2 / 3',
+  background: props.theme.colors.mono200,
+  overflow: 'scroll',
+  [`@media screen and (max-width: ${props.theme.breakpoints.medium})`]: {
+    order: 3,
+    overflow: 'inherit'
+  }
+}));
+
+// example
+
+export const MainExample = styled.main(props => ({
+  height: 'calc(100vh - 96px)',
+  [`@media screen and (max-width: ${props.theme.breakpoints.medium})`]: {
+    marginTop: '64px'
+  }
+}));
+
+// examples
+
+export const MainExamples = styled.main(props => ({
+  background: props.theme.colors.mono100,
+  display: 'flex',
+  flexWrap: 'wrap',
+  [`@media screen and (max-width: ${theme.breakpoints.medium})`]: {
+    marginTop: '64px'
+  }
+}));
+
+export const ExampleCard = styled.div(props => ({
+  border: props.theme.border300,
+  cursor: 'pointer',
+  margin: props.theme.sizing.scale400,
+  padding: `${props.theme.sizing.scale700} ${props.theme.sizing.scale600} ${
+    props.theme.sizing.scale700
+  } ${props.theme.sizing.scale600}`,
+  transition: `background ${props.theme.animation.timing400} border-color ${
+    props.theme.animation.timing400
+  }`,
+  transitionTimingFunction: theme.animation.easeInOutCurve,
+  '&:hover': {
+    background: props.theme.colors.mono200,
+    borderColor: 'transparent'
+  }
+}));
+
+export const ExampleTitle = styled.div(props => ({
+  color: theme.colors.mono1000,
+  ...props.theme.typography.font,
+  marginBottom: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  width: '150px'
+}));
+
+// search
+
+export const SearchContainer = styled.div(props => ({
+  position: 'relative',
+  height: props.theme.sizing.scale1000,
+  marginBottom: '20px',
+  background: props.theme.colors.mono200
+}));
+
+export const IconContainer = styled.div(props => ({
+  position: 'absolute',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: props.theme.sizing.scale1000,
+  height: props.theme.sizing.scale1000
+}));
+
+export const InputSearch = styled.input`
+  box-shadow: rgba(0, 0, 0, 0) 0px 2px 6px;
+  border: 1px solid transparent;
+  transition: 0.3s;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  padding: 10px 10px 10px 40px;
+  :focus {
+    box-shadow: rgba(39, 110, 241, 0.32) 0px 2px 6px;
+    border-color: rgb(39, 110, 241);
+    outline: none;
+  }
+`;
+
+export const MainSearch = styled.main`
+  max-width: 600px;
+  margin: 104px auto 0px;
+`;

--- a/modules/gatsby/src/components/styled/theme.js
+++ b/modules/gatsby/src/components/styled/theme.js
@@ -1,0 +1,439 @@
+export const lightThemePrimitives = {
+  primary50: '#EDF3FE',
+  primary100: '#D2E0FC',
+  primary200: '#9CBCF8',
+  primary300: '#548BF4',
+  primary400: '#276EF1',
+  primary500: '#174EB6',
+  primary600: '#123D90',
+  primary700: '#0C2960',
+
+  negative50: '#FDF0EF',
+  negative100: '#FADBD7',
+  negative200: '#F4AFA7',
+  negative300: '#EB7567',
+  negative400: '#E54937',
+  negative500: '#AE372A',
+  negative600: '#892C21',
+  negative700: '#5C1D16',
+
+  warning50: '#FEF3EC',
+  warning100: '#FBE2CF',
+  warning200: '#F6BA8B',
+  warning300: '#F19248',
+  warning400: '#ED6F0E',
+  warning500: '#B4540B',
+  warning600: '#8E4308',
+  warning700: '#5F2C06',
+
+  positive50: '#EBF8F2',
+  positive100: '#CDEDDE',
+  positive200: '#88D3B0',
+  positive300: '#43B982',
+  positive400: '#07A35A',
+  positive500: '#057C44',
+  positive600: '#046236',
+  positive700: '#034124',
+
+  mono100: '#FFFFFF',
+  mono200: '#F7F7F7',
+  mono300: '#F0F0F0',
+  mono400: '#E5E5E5',
+  mono500: '#CCCCCC',
+  mono600: '#B3B3B3',
+  mono700: '#999999',
+  mono800: '#666666',
+  mono900: '#333333',
+  mono1000: '#000000',
+
+  rating200: '#FFE1A5',
+  rating400: '#FFC043',
+
+  primaryFontFamily:
+    'system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif',
+};
+
+const WHITE = '#FFFFFF';
+
+export function createTheme(primitives) {
+  return {
+  breakpoints: {
+    small: 320,
+    medium: 600,
+    large: 1280,
+  },
+
+  colors: {
+    // Primary Palette
+    primary50: primitives.primary50,
+    primary100: primitives.primary100,
+    primary200: primitives.primary200,
+    primary300: primitives.primary300,
+    primary400: primitives.primary400,
+    primary: primitives.primary400,
+    primary500: primitives.primary500,
+    primary600: primitives.primary600,
+    primary700: primitives.primary700,
+
+    // Negative Palette
+    negative50: primitives.negative50,
+    negative100: primitives.negative100,
+    negative200: primitives.negative200,
+    negative300: primitives.negative300,
+    negative400: primitives.negative400,
+    negative: primitives.negative400,
+    negative500: primitives.negative500,
+    negative600: primitives.negative600,
+    negative700: primitives.negative700,
+
+    // Warning Palette
+    warning50: primitives.warning50,
+    warning100: primitives.warning100,
+    warning200: primitives.warning200,
+    warning300: primitives.warning300,
+    warning400: primitives.warning400,
+    warning: primitives.warning400,
+    warning500: primitives.warning500,
+    warning600: primitives.warning600,
+    warning700: primitives.warning700,
+
+    // Positive Palette
+    positive50: primitives.positive50,
+    positive100: primitives.positive100,
+    positive200: primitives.positive200,
+    positive300: primitives.positive300,
+    positive400: primitives.positive400,
+    positive: primitives.positive400,
+    positive500: primitives.positive500,
+    positive600: primitives.positive600,
+    positive700: primitives.positive700,
+
+    // Monochrome Palette
+    white: primitives.mono100,
+    mono100: primitives.mono100,
+    mono200: primitives.mono200,
+    mono300: primitives.mono300,
+    mono400: primitives.mono400,
+    mono500: primitives.mono500,
+    mono600: primitives.mono600,
+    mono700: primitives.mono700,
+    mono800: primitives.mono800,
+    mono900: primitives.mono900,
+    mono1000: primitives.mono1000,
+    black: primitives.mono1000,
+
+    // Rating Palette,
+    rating200: primitives.rating200,
+    rating400: primitives.rating400,
+
+    // Semantic Colors
+
+    // Font Color
+    colorPrimary: primitives.mono1000,
+    colorSecondary: primitives.mono800,
+
+    // Background
+    background: primitives.mono100,
+    backgroundAlt: primitives.mono100,
+    backgroundInv: primitives.mono1000,
+
+    // Foreground
+    foreground: primitives.mono1000,
+    foregroundAlt: primitives.mono800,
+    foregroundInv: primitives.mono100,
+
+    // Borders
+    border: primitives.mono500,
+    borderAlt: primitives.mono600,
+    borderFocus: primitives.primary400,
+    borderError: primitives.negative400,
+
+    // Buttons
+    buttonPrimaryFill: primitives.primary400,
+    buttonPrimaryText: primitives.mono100, // white
+    buttonPrimaryHover: primitives.primary500,
+    buttonPrimaryActive: primitives.primary600,
+
+    buttonSecondaryFill: primitives.primary50,
+    buttonSecondaryText: primitives.primary400,
+    buttonSecondaryHover: primitives.primary100,
+    buttonSecondaryActive: primitives.primary200,
+
+    buttonTertiaryFill: primitives.mono200,
+    buttonTertiaryText: primitives.primary400,
+    buttonTertiaryHover: primitives.mono400,
+    buttonTertiaryActive: primitives.mono500,
+    // button $selected only applies to tertiary variant.
+    buttonTertiarySelectedFill: primitives.primary400,
+    buttonTertiarySelectedText: primitives.mono100,
+
+    buttonMinimalFill: 'transparent',
+    buttonMinimalText: primitives.primary400,
+    buttonMinimalHover: primitives.mono200,
+    buttonMinimalActive: primitives.mono400,
+
+    buttonDisabledFill: primitives.mono300,
+    buttonDisabledText: primitives.mono600,
+
+    // Breadcrumbs
+    breadcrumbsText: primitives.mono900,
+    breadcrumbsSeparatorFill: primitives.mono700,
+
+    // FileUploader
+    fileUploaderBackgroundColor: primitives.mono200,
+    fileUploaderBackgroundColorActive: primitives.primary50,
+    fileUploaderBorderColorActive: primitives.primary400,
+    fileUploaderBorderColorDefault: primitives.mono500,
+    fileUploaderMessageColor: primitives.mono600,
+
+    // Links
+    linkText: primitives.primary400,
+    linkVisited: primitives.primary500,
+    linkHover: primitives.primary600,
+
+    // Shadow
+    shadowFocus: 'rgba(39, 110, 241, 0.32)',
+    shadowError: 'rgba(229, 73, 55, 0.32)',
+
+    // List
+    listHeaderFill: WHITE,
+    listBodyFill: primitives.mono200,
+    listIconFill: primitives.mono500,
+    listBorder: primitives.mono500,
+
+    // Tick
+    tickFill: 'transparent',
+    tickFillHover: primitives.mono400,
+    tickFillActive: primitives.mono500,
+    tickFillSelected: primitives.primary400,
+    tickFillSelectedHover: primitives.primary500,
+    tickFillSelectedHoverActive: primitives.primary600,
+    tickFillDisabled: primitives.mono400,
+    tickBorder: primitives.mono700,
+    tickMarkFill: WHITE,
+
+    // Slider
+    sliderTrackFill: primitives.mono600,
+    sliderTrackFillHover: primitives.mono700,
+    sliderTrackFillActive: primitives.mono800,
+    sliderTrackFillSelected: primitives.primary400,
+    sliderTrackFillSelectedHover: primitives.primary500,
+    sliderTrackFillSelectedActive: primitives.primary600,
+    sliderTrackFillDisabled: primitives.mono600,
+    sliderHandleFill: WHITE,
+    sliderHandleFillHover: WHITE,
+    sliderHandleFillActive: WHITE,
+    sliderHandleFillSelected: WHITE,
+    sliderHandleFillSelectedHover: WHITE,
+    sliderHandleFillSelectedActive: WHITE,
+    sliderHandleFillDisabled: primitives.mono500,
+    sliderBorder: primitives.mono500,
+    sliderBorderHover: primitives.primary400,
+    sliderBorderDisabled: primitives.mono600,
+
+    // Inputs
+    inputFill: primitives.mono200,
+    inputFillEnhancer: primitives.mono400,
+    inputFillError: primitives.negative50,
+    inputFillDisabled: primitives.mono300,
+    inputTextDisabled: primitives.mono600,
+
+    // Menu
+    menuFillHover: primitives.mono300,
+
+    // Notification
+    notificationPrimaryBackground: primitives.primary50,
+    notificationPrimaryText: primitives.primary500,
+    notificationPositiveBackground: primitives.positive50,
+    notificationPositiveText: primitives.positive500,
+    notificationWarningBackground: primitives.warning50,
+    notificationWarningText: primitives.warning500,
+    notificationNegativeBackground: primitives.negative50,
+    notificationNegativeText: primitives.negative500,
+
+    // Table
+    tableHeadBackgroundColor: primitives.mono100,
+
+    // Toast
+    toastText: WHITE,
+    toastPrimaryBackground: primitives.primary500,
+    toastPositiveBackground: primitives.positive500,
+    toastWarningBackground: primitives.warning500,
+    toastNegativeBackground: primitives.negative500,
+  },
+  typography: {
+    font100: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '11px',
+      fontWeight: 'normal',
+      lineHeight: '16px',
+    },
+    font200: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '12px',
+      fontWeight: 'normal',
+      lineHeight: '20px',
+    },
+    font250: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '12px',
+      fontWeight: 'bold',
+      lineHeight: '20px',
+    },
+    font300: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '14px',
+      fontWeight: 'normal',
+      lineHeight: '20px',
+    },
+    font350: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '14px',
+      fontWeight: 'bold',
+      lineHeight: '20px',
+    },
+    font400: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '16px',
+      fontWeight: 'normal',
+      lineHeight: '24px',
+    },
+    font450: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '16px',
+      fontWeight: 'bold',
+      lineHeight: '24px',
+    },
+    font500: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '20px',
+      fontWeight: 'bold',
+      lineHeight: '28px',
+    },
+    font600: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '24px',
+      fontWeight: 'bold',
+      lineHeight: '36px',
+    },
+    font700: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '32px',
+      fontWeight: 'bold',
+      lineHeight: '48px',
+    },
+    font800: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '40px',
+      fontWeight: 'bold',
+      lineHeight: '56px',
+    },
+    font900: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '52px',
+      fontWeight: 'bold',
+      lineHeight: '68px',
+    },
+    font1000: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '72px',
+      fontWeight: 'normal',
+      lineHeight: '96px',
+    },
+    font1100: {
+      fontFamily: primitives.primaryFontFamily,
+      fontSize: '96px',
+      fontWeight: 'normal',
+      lineHeight: '116px',
+    },
+  },
+  sizing: {
+    scale0: '2px',
+    scale100: '4px',
+    scale200: '6px',
+    scale300: '8px',
+    scale400: '10px',
+    scale500: '12px',
+    scale550: '14px',
+    scale600: '16px',
+    scale700: '20px',
+    scale800: '24px',
+    scale900: '32px',
+    scale1000: '40px',
+    scale1200: '48px',
+    scale1400: '56px',
+    scale1600: '64px',
+    scale2400: '96px',
+    scale3200: '128px',
+    scale4800: '192px',
+  },
+  lighting: {
+    shadow400: '0 1px 4px hsla(0, 0%, 0%, 0.16)',
+    shadow500: '0 2px 8px hsla(0, 0%, 0%, 0.16)',
+    shadow600: '0 4px 16px hsla(0, 0%, 0%, 0.16)',
+    shadow700: '0 8px 24px hsla(0, 0%, 0%, 0.16)',
+    overlay0: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0)',
+    overlay100: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.04)',
+    overlay200: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.08)',
+    overlay300: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.12)',
+    overlay400: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.16)',
+    overlay500: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.2)',
+    overlay600: 'inset 0 0 0 1000px hsla(0, 0%, 0%, 0.24)',
+  },
+  borders: {
+    border100: {
+      borderColor: 'hsla(0, 0%, 0%, 0.04)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    border200: {
+      borderColor: 'hsla(0, 0%, 0%, 0.08)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    border300: {
+      borderColor: 'hsla(0, 0%, 0%, 0.12)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    border400: {
+      borderColor: 'hsla(0, 0%, 0%, 0.16)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    border500: {
+      borderColor: 'hsla(0, 0%, 0%, 0.2)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    border600: {
+      borderColor: 'hsla(0, 0%, 0%, 0.24)',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    radius100: '2px',
+    radius200: '4px',
+    radius300: '8px',
+    radius400: '12px',
+    useRoundedCorners: true,
+  },
+  animation: {
+    timing100: '0.25s',
+    timing400: '0.4s',
+    timing700: '0.6s',
+    easeOutCurve: 'cubic-bezier(.2, .8, .4, 1)',
+    easeInCurve: 'cubic-bezier(.8, .2, .6, 1)',
+    easeInOutCurve: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  },
+  zIndex: {
+    modal: 2000,
+  },
+  tooltip: {
+    backgroundColor: primitives.mono900,
+  },
+  };
+}
+
+const theme = createTheme(lightThemePrimitives);
+
+export default theme;

--- a/modules/gatsby/src/templates/example-n.jsx
+++ b/modules/gatsby/src/templates/example-n.jsx
@@ -2,12 +2,11 @@ import React from 'react';
 
 import { graphql } from 'gatsby';
 import { AutoSizer } from 'react-virtualized';
-import theme from '../components/styled/theme';
 
 import ExampleTableOfContents from '../components/layout/example-table-of-contents';
-
 import { getReactComponent } from '../utils/component-registry';
 import { MainExample } from '../components/styled';
+import WithConfig from '../components/layout/website-config';
 
 /* eslint no-undef: "off" */
 export const query = graphql`
@@ -26,7 +25,6 @@ export const query = graphql`
   }
 `;
 
-
 export default class ExampleTemplate extends React.Component {
   render() {
     const { pathContext, pageResources } = this.props;
@@ -40,24 +38,32 @@ export default class ExampleTemplate extends React.Component {
     if (!example) {
       console.warn(`No example found: ${slug}`);
     }
-
+    console.log(this.props);
     // console.log(example);
 
     return (
-      <MainExample theme={theme}>
-        <AutoSizer>
-          {({ height, width }) =>
-            example && (
-              <DemoRunner
-                height={height}
-                example={example}
-                sourceLink={pageResources && pageResources.page && pageResources.page.path}
-                width={width}
-              />
-            )
-          }
-        </AutoSizer>
-      </MainExample>
+      <WithConfig>
+        {({ theme }) => (
+          <MainExample theme={theme}>
+            <AutoSizer>
+              {({ height, width }) =>
+                  example && (
+                    <DemoRunner
+                      height={height}
+                      example={example}
+                      sourceLink={
+                        pageResources &&
+                        pageResources.page &&
+                        pageResources.page.path
+                      }
+                      width={width}
+                    />
+                  )
+                }
+            </AutoSizer>
+          </MainExample>
+          )}
+      </WithConfig>
     );
   }
 }

--- a/modules/gatsby/src/templates/example-n.jsx
+++ b/modules/gatsby/src/templates/example-n.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import styled from 'styled-components';
+
 import { graphql } from 'gatsby';
 import { AutoSizer } from 'react-virtualized';
+import theme from '../components/styled/theme';
 
 import ExampleTableOfContents from '../components/layout/example-table-of-contents';
 
 import { getReactComponent } from '../utils/component-registry';
+import { MainExample } from '../components/styled';
 
 /* eslint no-undef: "off" */
 export const query = graphql`
@@ -24,12 +26,6 @@ export const query = graphql`
   }
 `;
 
-const Main = styled.main`
-  height: calc(100vh - 96px);
-  @media screen and (max-width: 600px) {
-    margin-top: 64px;
-  }
-`;
 
 export default class ExampleTemplate extends React.Component {
   render() {
@@ -48,7 +44,7 @@ export default class ExampleTemplate extends React.Component {
     // console.log(example);
 
     return (
-      <Main>
+      <MainExample theme={theme}>
         <AutoSizer>
           {({ height, width }) =>
             example && (
@@ -61,7 +57,7 @@ export default class ExampleTemplate extends React.Component {
             )
           }
         </AutoSizer>
-      </Main>
+      </MainExample>
     );
   }
 }

--- a/modules/gatsby/src/templates/examples.jsx
+++ b/modules/gatsby/src/templates/examples.jsx
@@ -1,48 +1,11 @@
 import React, { Component } from 'react';
-import styled from 'styled-components';
 import { Link } from 'gatsby';
+import theme from '../components/styled/theme';
 
 import { graphql } from 'gatsby';
 
 import ExampleTableOfContents from '../components/layout/example-table-of-contents';
-
-const colors = {
-  black: '#000',
-  gray6: '#f6f6f6',
-  white: '#fff'
-};
-
-const Main = styled.main`
-  background: ${colors.white};
-  display: flex;
-  flex-wrap: wrap;
-  @media screen and (max-width: 600px) {
-    margin-top: 64px;
-  }
-`;
-
-const ExampleCard = styled.div`
-  border: 1px solid ${colors.gray6};
-  cursor: pointer;
-  margin: 10px;
-  padding: 20px 16px;
-  transition: background 0.3s border-color 0.3s;
-  &:hover {
-    background: ${colors.gray6};
-    border-color: transparent;
-  }
-`;
-
-const ExampleTitle = styled.div`
-  color: ${colors.black};
-  font-size: 14px;
-  font-weight: 500;
-  margin-bottom: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 150px;
-`;
+import { MainExamples, ExampleCard, ExampleTitle } from '../components/styled';
 
 /* eslint no-undef: "off" */
 
@@ -71,18 +34,18 @@ export default class Examples extends Component {
       pageContext: { examples }
     } = this.props;
     return (
-      <Main>
+      <MainExamples theme={theme}>
         {examples.map(exampleData => (
-          <ExampleCard>
+          <ExampleCard theme={theme}>
             <Link to={exampleData.path}>
               {exampleData.imageSrc ? (
                 <img src={exampleData.imageSrc} alt={exampleData.title} />
               ) : null}
-              <ExampleTitle>{exampleData.title}</ExampleTitle>
+              <ExampleTitle theme={theme}>{exampleData.title}</ExampleTitle>
             </Link>
           </ExampleCard>
         ))}
-      </Main>
+      </MainExamples>
     );
   }
 }

--- a/modules/gatsby/src/templates/examples.jsx
+++ b/modules/gatsby/src/templates/examples.jsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { Link } from 'gatsby';
-import theme from '../components/styled/theme';
 
 import { graphql } from 'gatsby';
 
 import ExampleTableOfContents from '../components/layout/example-table-of-contents';
 import { MainExamples, ExampleCard, ExampleTitle } from '../components/styled';
+import WithConfig from '../components/layout/website-config';
 
 /* eslint no-undef: "off" */
 
@@ -34,18 +34,22 @@ export default class Examples extends Component {
       pageContext: { examples }
     } = this.props;
     return (
-      <MainExamples theme={theme}>
-        {examples.map(exampleData => (
-          <ExampleCard theme={theme}>
-            <Link to={exampleData.path}>
-              {exampleData.imageSrc ? (
-                <img src={exampleData.imageSrc} alt={exampleData.title} />
-              ) : null}
-              <ExampleTitle theme={theme}>{exampleData.title}</ExampleTitle>
-            </Link>
-          </ExampleCard>
-        ))}
-      </MainExamples>
+      <WithConfig>
+        {({ theme }) => (
+          <MainExamples theme={theme}>
+            {examples.map(exampleData => (
+              <ExampleCard theme={theme}>
+                <Link to={exampleData.path}>
+                  {exampleData.imageSrc ? (
+                    <img src={exampleData.imageSrc} alt={exampleData.title} />
+                  ) : null}
+                  <ExampleTitle theme={theme}>{exampleData.title}</ExampleTitle>
+                </Link>
+              </ExampleCard>
+            ))}
+          </MainExamples>
+        )}
+      </WithConfig>
     );
   }
 }

--- a/modules/gatsby/src/templates/search.jsx
+++ b/modules/gatsby/src/templates/search.jsx
@@ -1,44 +1,18 @@
 import React from 'react';
 import debounce from 'lodash.debounce';
-import styled from 'styled-components';
 import { Link } from 'gatsby';
 import SearchIcon from '../components/images/search-filled.svg';
+import theme from '../components/styled/theme';
 
 import WebsiteConfigConsumer from '../components/layout/website-config';
+import {
+  MainSearch,
+  SearchContainer,
+  IconContainer,
+  InputSearch
+} from '../components/styled';
+// import { setHeaderOpacity } from '../../../classic/base/reducers/ui';
 
-const SearchContainer = styled.div`
-  position: relative;
-  height: 40px;
-  margin-bottom: 20px;
-  background: #f7f7f7;
-`;
-const IconContainer = styled.div`
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-`;
-const Input = styled.input`
-  box-shadow: rgba(0, 0, 0, 0) 0px 2px 6px;
-  border: 1px solid transparent;
-  transition: 0.3s;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
-  padding: 10px 10px 10px 40px;
-  :focus {
-    box-shadow: rgba(39, 110, 241, 0.32) 0px 2px 6px;
-    border-color: rgb(39, 110, 241);
-    outline: none;
-  }
-`;
-
-const Main = styled.main`
-  max-width: 600px;
-  margin: 104px auto 0px;
-`;
 export default class SearchPage extends React.Component {
   constructor(props) {
     super(props);
@@ -79,18 +53,19 @@ export default class SearchPage extends React.Component {
     const { debouncing, results, currentQuery } = this.state;
     const { pathContext } = this.props;
     return (
-      <Main>
+      <MainSearch theme={theme}>
         <div className="fcol f fg container p2">
-          <SearchContainer>
-            <IconContainer>
+          <SearchContainer theme={theme}>
+            <IconContainer theme={theme}>
               <img src={SearchIcon} alt="search" height="16" width="16" />
             </IconContainer>
             <div className="fg">
-              <Input
+              <InputSearch
                 type="text"
                 placeholder="Search"
                 onChange={this.handleChange}
                 value={currentQuery}
+                theme={theme}
                 style={{ width: '100%' }}
               />
             </div>
@@ -125,7 +100,7 @@ export default class SearchPage extends React.Component {
             </div>
           </div>
         </div>
-      </Main>
+      </MainSearch>
     );
   }
 

--- a/modules/gatsby/src/templates/search.jsx
+++ b/modules/gatsby/src/templates/search.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import debounce from 'lodash.debounce';
 import { Link } from 'gatsby';
 import SearchIcon from '../components/images/search-filled.svg';
-import theme from '../components/styled/theme';
+import WithConfig from '../components/layout/website-config';
 
 import WebsiteConfigConsumer from '../components/layout/website-config';
 import {
@@ -53,54 +53,58 @@ export default class SearchPage extends React.Component {
     const { debouncing, results, currentQuery } = this.state;
     const { pathContext } = this.props;
     return (
-      <MainSearch theme={theme}>
-        <div className="fcol f fg container p2">
-          <SearchContainer theme={theme}>
-            <IconContainer theme={theme}>
-              <img src={SearchIcon} alt="search" height="16" width="16" />
-            </IconContainer>
-            <div className="fg">
-              <InputSearch
-                type="text"
-                placeholder="Search"
-                onChange={this.handleChange}
-                value={currentQuery}
-                theme={theme}
-                style={{ width: '100%' }}
-              />
-            </div>
-          </SearchContainer>
-
-          {debouncing ? <div>Searching...</div> : null}
-          <div>
-            {currentQuery && !debouncing && (
-              <div>
-                {results.length
-                  ? `${results.length} articles found.`
-                  : `No result for this query.`}
-              </div>
-            )}
-
-            {!currentQuery && !debouncing && (
-              <div>
-                {pathContext.data
-                  ? `${pathContext.data.length} articles indexed.`
-                  : ''}
-              </div>
-            )}
-            <div className="results">
-              {results.map(result => (
-                <div className="search-item" key={result.slug}>
-                  <div className="search-title">
-                    <Link to={result.slug}>{result.title}</Link>
-                  </div>
-                  <div className="search-content">{result.excerpt}</div>
+      <WithConfig>
+        {({ theme }) => (
+          <MainSearch theme={theme}>
+            <div className="fcol f fg container p2">
+              <SearchContainer theme={theme}>
+                <IconContainer theme={theme}>
+                  <img src={SearchIcon} alt="search" height="16" width="16" />
+                </IconContainer>
+                <div className="fg">
+                  <InputSearch
+                    type="text"
+                    placeholder="Search"
+                    onChange={this.handleChange}
+                    value={currentQuery}
+                    theme={theme}
+                    style={{ width: '100%' }}
+                  />
                 </div>
-              ))}
+              </SearchContainer>
+
+              {debouncing ? <div>Searching...</div> : null}
+              <div>
+                {currentQuery && !debouncing && (
+                  <div>
+                    {results.length
+                      ? `${results.length} articles found.`
+                      : `No result for this query.`}
+                  </div>
+                )}
+
+                {!currentQuery && !debouncing && (
+                  <div>
+                    {pathContext.data
+                      ? `${pathContext.data.length} articles indexed.`
+                      : ''}
+                  </div>
+                )}
+                <div className="results">
+                  {results.map(result => (
+                    <div className="search-item" key={result.slug}>
+                      <div className="search-title">
+                        <Link to={result.slug}>{result.title}</Link>
+                      </div>
+                      <div className="search-content">{result.excerpt}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </MainSearch>
+          </MainSearch>
+        )}
+      </WithConfig>
     );
   }
 


### PR DESCRIPTION
This PR lays the groundwork for having styling done (almost) entirely in CSS-in-JS as opposed to rely on SCSS. The reasoning for moving towards a CSS-in-JS solution is that we can have everything configured in a central place as opposed to have to hope that variables in the code are consistent with variables in stylesheets.

To that end, it creates a central list of styled components. These components are created, today, with styled-components but it would be easy to move to styletron if that's where we going. styled-components doesn't have to be imported anywhere else.

It also creates a theme.js file which contains primitives (descriptions of colors, spacing etc.) and a method to create a theme (one or several css properties directly usable on a component). This is copied from baseUI. 

Finally it passes that theme through the website-config context consumer. Possibly a more specialized theme consumer could be created though that's directly what baseUI does. 

Note that I haven't been able to add theme overrides to the static query in layout - any change resulting in a never ending StaticQuery(loading). 

