### PR TITLE
[dev-tools] Add config system

### DIFF
--- a/modules/dev-tools/config/babel.config.js
+++ b/modules/dev-tools/config/babel.config.js
@@ -1,3 +1,5 @@
+const config = require('./ocular.config');
+
 const TARGETS = {
   chrome: '60',
   edge: '15',
@@ -7,10 +9,21 @@ const TARGETS = {
   node: '8'
 };
 
+function mergeEnvSettings(env, defaultSettings) {
+  const envConfig = config.babel[env] || {};
+  const presets = envConfig.presets || config.presets || [];
+  const plugins = envConfig.plugins || config.plugins || [];
+
+  return Object.assign({}, defaultSettings, {
+    presets: defaultSettings.presets.concat(presets),
+    plugins: defaultSettings.plugins.concat(plugins)
+  });
+}
+
 module.exports = {
   comments: false,
   env: {
-    es5: {
+    es5: mergeEnvSettings('es5', {
       presets: [
         [ '@babel/env', {
           forceAllTransforms: true,
@@ -18,11 +31,10 @@ module.exports = {
         }]
       ],
       plugins: [
-        '@babel/transform-runtime',
-        'version-inline'
+        '@babel/transform-runtime'
       ]
-    },
-    esm: {
+    }),
+    esm: mergeEnvSettings('esm', {
       presets: [
         [ '@babel/env', {
           forceAllTransforms: true,
@@ -30,11 +42,10 @@ module.exports = {
         }]
       ],
       plugins: [
-        ['@babel/transform-runtime', {useESModules: true}],
-        'version-inline'
+        ['@babel/transform-runtime', {useESModules: true}]
       ]
-    },
-    es6: {
+    }),
+    es6: mergeEnvSettings('es6', {
       presets: [
         [ '@babel/env', {
           targets: TARGETS,
@@ -45,11 +56,12 @@ module.exports = {
         ['@babel/transform-runtime', {useESModules: true}],
         'version-inline'
       ]
-    },
-    test: {
+    }),
+    test: mergeEnvSettings('test', {
+      presets: [],
       plugins: [
         'istanbul'
       ]
-    }
+    })
   }
 };

--- a/modules/dev-tools/config/ocular.config.js
+++ b/modules/dev-tools/config/ocular.config.js
@@ -1,0 +1,29 @@
+const {resolve} = require('path');
+
+const DEFAULT_CONFIG = {
+  babel: {
+    plugins: ['version-inline']
+  },
+
+  aliases: {},
+
+  entry: {
+    'test-node': 'test/node',
+    'test-browser': 'test/browser',
+    'bench-node': 'test/bench/node',
+    'bench-browser': 'test/bench/browser',
+  }
+};
+
+let userConfig;
+try {
+  userConfig = require(resolve('./ocular.config.js'));
+} catch (err) {
+  userConfig = {};
+}
+
+module.exports = {
+  babel: Object.assign(DEFAULT_CONFIG.babel, userConfig.aliases),
+  aliases: Object.assign(DEFAULT_CONFIG.aliases, userConfig.aliases),
+  entry: Object.assign(DEFAULT_CONFIG.entry, userConfig.entry)
+};

--- a/modules/dev-tools/node/module-dir.js
+++ b/modules/dev-tools/node/module-dir.js
@@ -1,0 +1,6 @@
+const {resolve} = require('path');
+
+// Prints the installed location of ocular-dev-tools
+module.exports = function() {
+  console.log(resolve(__dirname, '..'));
+};

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "config",
+    "node",
     "scripts",
     "templates"
   ],

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -2,16 +2,17 @@
 
 set -e
 
-build_module() {
-  CONFIG=$1
+DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
+CONFIG=$DEV_TOOLS_DIR/config/babel.config.js
 
+build_module() {
   BABEL_ENV=es6 npx babel src --config-file $CONFIG --out-dir dist/es6 --source-maps
   BABEL_ENV=esm npx babel src --config-file $CONFIG --out-dir dist/esm --source-maps
   BABEL_ENV=es5 npx babel src --config-file $CONFIG --out-dir dist/es5 --source-maps
 }
 
 build_unirepo() {
-  build_module ./babel.config.js
+  build_module
 }
 
 build_monorepo() {
@@ -29,7 +30,7 @@ build_monorepo() {
   for D in ${MODULES}; do (
     echo "\033[1mBuilding modules/$D\033[0m"
     cd $D
-    build_module ../../babel.config.js
+    build_module
     echo ""
   ); done
 }


### PR DESCRIPTION
This is a proof of concept.
Repos that use ocular-dev-tools can provide a single `ocular.config.js` at root for customizing the dev process. At run time, ocular merges these user configs with the default templates. This eliminates the need to manually create endpoints such as `babel.config.js`, `.eslintrc.js`, `test/webpack.config.js`, `test/start.js` etc.