### PR TITLE
[dev-tools] Support babel/webpack config files in package

### DIFF
--- a/modules/dev-tools/config/ocular.config.js
+++ b/modules/dev-tools/config/ocular.config.js
@@ -5,7 +5,11 @@ const IS_MONOREPO = fs.existsSync(resolve('./modules'));
 
 const DEFAULT_CONFIG = {
   babel: {
-    plugins: ['version-inline']
+    configPath: getValidPath([
+      resolve('./babel.config.js'),
+      resolve('./babelrc'),
+      resolve(__dirname, './babel.config.js')
+    ])
   },
 
   lint: {
@@ -16,11 +20,18 @@ const DEFAULT_CONFIG = {
   aliases: {},
 
   entry: {
-    'test-node': 'test/node',
+    'test': 'test/index',
     'test-browser': 'test/browser',
-    'bench-node': 'test/bench/node',
+    'bench': 'test/bench/index',
     'bench-browser': 'test/bench/browser',
     'size': 'test/size'
+  },
+
+  webpack: {
+    configPath: getValidPath([
+      resolve('./webpack.config.js'),
+      resolve(__dirname, './webpack.config.js')
+    ])
   }
 };
 
@@ -40,6 +51,10 @@ function shallowMerge(obj1, obj2) {
   });
 
   return result;
+}
+
+function getValidPath(resolveOrder) {
+  return resolveOrder.find(path => fs.existsSync(path));
 }
 
 module.exports = shallowMerge(DEFAULT_CONFIG, userConfig);

--- a/modules/dev-tools/config/ocular.config.js
+++ b/modules/dev-tools/config/ocular.config.js
@@ -7,7 +7,7 @@ const DEFAULT_CONFIG = {
   babel: {
     configPath: getValidPath([
       resolve('./babel.config.js'),
-      resolve('./babelrc'),
+      resolve('./.babelrc'),
       resolve(__dirname, './babel.config.js')
     ])
   },

--- a/modules/dev-tools/config/webpack.config.js
+++ b/modules/dev-tools/config/webpack.config.js
@@ -65,10 +65,10 @@ const MAIN_FIELDS = {
   es5: ['main']
 };
 
-function getBundleEntryPoints() {
-  let entry = config.entry['size'];
+function getEntryPoints(key) {
+  let entry = config.entry[key] || {};
   if (typeof entry === 'string') {
-    entry = {bundle: entry};
+    entry = {[key]: entry};
   }
   for (const key in entry) {
     entry[key] = resolve(entry[key]);
@@ -79,25 +79,12 @@ function getBundleEntryPoints() {
 // Replace the entry point for webpack-dev-server
 module.exports = (env = {}) => {
   switch (env.mode) {
-  case 'bench':
-    return Object.assign({}, COMMON_CONFIG, {
-      entry: {
-        bench: resolve(config.entry['bench-browser'])
-      }
-    });
 
-  case 'test':
-    return Object.assign({}, COMMON_CONFIG, {
-      entry: {
-        test: resolve(config.entry['test-browser'])
-      }
-    });
-
-  case 'bundle':
+  case 'size':
     return Object.assign({}, COMMON_CONFIG, {
       mode: 'production',
 
-      entry: getBundleEntryPoints(),
+      entry: getEntryPoints('size'),
 
       resolve: Object.assign({}, COMMON_CONFIG.resolve, {
         mainFields: MAIN_FIELDS[env.dist] || MAIN_FIELDS.esm
@@ -112,7 +99,7 @@ module.exports = (env = {}) => {
     return Object.assign({}, COMMON_CONFIG, {
       mode: 'production',
 
-      entry: getBundleEntryPoints(),
+      entry: getEntryPoints('size'),
 
       devtool: false,
 
@@ -120,8 +107,12 @@ module.exports = (env = {}) => {
     });
     break;
 
+  case 'bench':
+  case 'test':
   default:
-    throw new Error `Unknown bundle mode ${env.mode}`;
+    return Object.assign({}, COMMON_CONFIG, {
+      entry: getEntryPoints(`${env.mode}-browser`)
+    });
   }
 
 };

--- a/modules/dev-tools/node/test.js
+++ b/modules/dev-tools/node/test.js
@@ -11,9 +11,14 @@ const getAliases = require('./aliases');
 moduleAlias.addAliases(getAliases('src'));
 
 const config = require('../config/ocular.config');
-const webpackConfigPath = resolve(__dirname, '../config/webpack.config');
 
-const {BrowserTestDriver} = require('@probe.gl/test-utils');
+// Browser test is opt-in by installing @probe.gl/test-utils
+let BrowserTestDriver = null;
+try {
+  BrowserTestDriver = require('@probe.gl/test-utils').BrowserTestDriver;
+} catch (error) {
+  BrowserTestDriver = null;
+}
 
 const mode = process.argv.length >= 3 ? process.argv[2] : 'default';
 console.log(`Running ${mode} tests...`); // eslint-disable-line
@@ -22,38 +27,60 @@ function resolveEntry(key) {
   return resolve(config.entry[key]);
 }
 
+function runBrowserTest(opts) {
+  if (BrowserTestDriver === null) {
+    console.log('\033[93m@probe.gl/test-utils is not installed, skipping browser test\033[0m');
+    process.exit(0);
+  }
+  return new BrowserTestDriver().run(opts);
+}
+
 switch (mode) {
   case 'node':
-    require(resolveEntry('test-node')); // Run the tests
+    require(resolveEntry('test')); // Run the tests
     break;
 
   case 'cover':
   case 'dist':
     // Load deck.gl itself from the dist folder
     moduleAlias.addAliases(getAliases('dist'));
-    require(resolveEntry('test-node')); // Run the tests
+    require(resolveEntry('test')); // Run the tests
     break;
 
   case 'bench':
-    require(resolveEntry('bench-node')); // Run the benchmarks
+    require(resolveEntry('bench')); // Run the benchmarks
     break;
 
   case 'browser':
   case 'browser-headless':
-    new BrowserTestDriver().run({
+    runBrowserTest({
       command: 'webpack-dev-server',
-      arguments: ['--config', webpackConfigPath, '--env.mode=test'],
+      arguments: ['--config', config.webpack.configPath, '--env.mode=test'],
       headless: mode === 'browser-headless'
     });
     break;
 
   case 'bench-browser':
-    new BrowserTestDriver().run({
+    runBrowserTest({
       command: 'webpack-dev-server',
-      arguments: ['--config', webpackConfigPath, '--env.mode=bench']
+      arguments: ['--config', config.webpack.configPath, '--env.mode=bench']
     });
     break;
 
   default:
-    throw new Error `Unknown test mode ${mode}`;
+    if (/\bbrowser\b/.test(mode)) {
+      runBrowserTest({
+        command: 'webpack-dev-server',
+        arguments: [
+          '--config',
+          config.webpack.configPath,
+          `--env.mode=${mode.replace('-browser', '').replace('-headless', '')}`
+        ],
+        headless: /\bheadless\b/.test(mode)
+      });
+    } else if (mode in config.entry) {
+      require(resolveEntry(mode));
+    } else {
+      throw new Error `Unknown test mode ${mode}`;
+    }
 }

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
-CONFIG=$DEV_TOOLS_DIR/config/babel.config.js
+CONFIG=`$DEV_TOOLS_DIR/scripts/print-config.sh ".babel.configPath"`
 
 build_module() {
   BABEL_ENV=es6 npx babel src --config-file $CONFIG --out-dir dist/es6 --source-maps

--- a/modules/dev-tools/scripts/lint.sh
+++ b/modules/dev-tools/scripts/lint.sh
@@ -9,12 +9,12 @@ MODE=$1
 
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 
-DIRECTORIES=`node -e "console.log(require('ocular-dev-tools/config/ocular.config').lint.paths.join(','))"`
+DIRECTORIES=`$DEV_TOOLS_DIR/scripts/print-config.sh ".lint.paths" | jq -r 'join(",")'`
 if [[ $DIRECTORIES == *","* ]]; then
   DIRECTORIES={$DIRECTORIES}
 fi
 
-EXTENSIONS=`node -e "console.log(require('ocular-dev-tools/config/ocular.config').lint.extensions.join(','))"`
+EXTENSIONS=`$DEV_TOOLS_DIR/scripts/print-config.sh ".lint.extensions" | jq -r 'join(",")'`
 if [[ $EXTENSIONS == *","* ]]; then
   EXTENSIONS={$EXTENSIONS}
 fi

--- a/modules/dev-tools/scripts/metrics.sh
+++ b/modules/dev-tools/scripts/metrics.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 # Script to collect build size information
 
-# set -e
+# set -ex
 
 export PATH=$PATH:node_modules/.bin
 
-MODULE_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
+DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 WORKING_DIR=`pwd`
 TMP_DIR=$WORKING_DIR/tmp
+
+# Get webpack config path
+WEBPACK_CONFIG=`$DEV_TOOLS_DIR/scripts/print-config.sh ".webpack.configPath"`
 
 # Get name from package.json
 module=$(jq '.name' ./package.json)
@@ -20,7 +23,7 @@ else
   packageInfo=./package.json
 fi
 # Get version from packag.json and remove quotes
-version=$(jq '.version' $packageInfo | awk '{ gsub(/"/,"",$1); printf "%-14s", $1 }')
+version=$(jq -r '.version' $packageInfo)
 
 # Helper functions
 
@@ -52,7 +55,7 @@ print_size() {
 
 build_bundle() {
   DIST=$1
-  NODE_ENV=production webpack --config $MODULE_DIR/config/webpack.config.js --output-path "$TMP_DIR" --hide-modules --env.mode=bundle --env.dist=$DIST > /dev/null
+  NODE_ENV=production webpack --config $WEBPACK_CONFIG --output-path "$TMP_DIR" --display errors-only --env.mode=size --env.dist=$DIST
 }
 
 print_bundle_size() {

--- a/modules/dev-tools/scripts/print-config.sh
+++ b/modules/dev-tools/scripts/print-config.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Script to collect build size information
+# Prints resolved config values
 
 # set -e
 

--- a/modules/dev-tools/scripts/print-config.sh
+++ b/modules/dev-tools/scripts/print-config.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Script to collect build size information
+
+# set -e
+
+CONFIG_NAME=$1
+
+node -e "let config = require('ocular-dev-tools/config/ocular.config')$CONFIG_NAME;\
+if (typeof config !== 'string') {\
+  config = JSON.stringify(config);\
+}\
+console.log(config)"


### PR DESCRIPTION
- babel uses `.babelrc`/`babel.config.js` in package root before falling back to default config
- webpack uses `webpack.config.js` in package root before falling back to default config
- remove babel config override from `ocular-dev-tools.config.js`
- Test script delegate the handling of unknown modes to user config files

I will add documentation in a follow up PR.