### PR TITLE
Allow configs to be used outside of package root

### DIFF
--- a/modules/dev-tools/README.md
+++ b/modules/dev-tools/README.md
@@ -161,7 +161,7 @@ module.exports = env => {
 
 #### ocular-dev-tools
 
-A file `ocular-dev-tools.config.js` can be placed at the root of the package to customize the dev scripts. The config file may export a JSON object that contains the following keys:
+A file `ocular-dev-tools.config.js` can be placed at the root of the package to customize the dev scripts. The config file may export a JSON object that contains the following keys, or a callback function that returns such object:
 
 - `lint`
   + `paths` (Arrray) - directories to include when linting. Default `['modules', 'src']`

--- a/modules/dev-tools/config/ocular.config.js
+++ b/modules/dev-tools/config/ocular.config.js
@@ -1,60 +1,77 @@
 const fs = require('fs');
 const {resolve} = require('path');
+const getAliases = require('../node/aliases');
 
-const IS_MONOREPO = fs.existsSync(resolve('./modules'));
-
-const DEFAULT_CONFIG = {
-  babel: {
-    configPath: getValidPath([
-      resolve('./babel.config.js'),
-      resolve('./.babelrc'),
-      resolve(__dirname, './babel.config.js')
-    ])
-  },
-
-  lint: {
-    paths: IS_MONOREPO ? ['modules'] : ['src'],
-    extensions: ['js', 'md']
-  },
-
-  aliases: {},
-
-  entry: {
-    'test': 'test/index',
-    'test-browser': 'test/browser',
-    'bench': 'test/bench/index',
-    'bench-browser': 'test/bench/browser',
-    'size': 'test/size'
-  },
-
-  webpack: {
-    configPath: getValidPath([
-      resolve('./webpack.config.js'),
-      resolve(__dirname, './webpack.config.js')
-    ])
+function shallowMerge(base, override) {
+  for (const key in override) {
+    if (base[key] && typeof base[key] === 'object') {
+      Object.assign(base[key], override[key])
+    } else {
+      base[key] = override[key];
+    }
   }
-};
-
-let userConfig;
-try {
-  userConfig = require(resolve('./ocular-dev-tools.config.js'));
-} catch (err) {
-  userConfig = {};
-}
-
-function shallowMerge(obj1, obj2) {
-  const result = {};
-  const keys = new Set(Object.keys(obj1).concat(Object.keys(obj2)));
-
-  keys.forEach(key => {
-    result[key] = Object.assign({}, obj1[key], obj2[key]);    
-  });
-
-  return result;
+  return base;
 }
 
 function getValidPath(resolveOrder) {
   return resolveOrder.find(path => fs.existsSync(path));
 }
 
-module.exports = shallowMerge(DEFAULT_CONFIG, userConfig);
+/*
+ * opts.root - path to package root, default `pwd`
+ * opts.aliasMode - default `src`
+ */
+module.exports = (opts = {}) => {
+  const packageRoot = opts.root || process.env.PWD;
+
+  const IS_MONOREPO = fs.existsSync(resolve(packageRoot, './modules'));
+
+  const config = {
+    babel: {
+      configPath: getValidPath([
+        resolve(packageRoot, './babel.config.js'),
+        resolve(packageRoot, './.babelrc'),
+        resolve(__dirname, './babel.config.js')
+      ])
+    },
+
+    lint: {
+      paths: IS_MONOREPO ? ['modules'] : ['src'],
+      extensions: ['js', 'md']
+    },
+
+    aliases: {},
+
+    entry: {
+      'test': 'test/index',
+      'test-browser': 'test/browser',
+      'bench': 'test/bench/index',
+      'bench-browser': 'test/bench/browser',
+      'size': 'test/size'
+    },
+
+    webpack: {
+      configPath: getValidPath([
+        resolve(packageRoot, './webpack.config.js'),
+        resolve(__dirname, './webpack.config.js')
+      ])
+    }
+  };
+
+  const userConfigPath = resolve(packageRoot, './ocular-dev-tools.config.js');
+  let userConfig = {};
+
+  if (fs.existsSync(userConfigPath)) {
+    userConfig = require(userConfigPath);
+    if (typeof userConfig === 'function') {
+      userConfig = userConfig(opts);
+    }
+  }
+
+  shallowMerge(config, userConfig);
+
+  // User's aliases need to come first, due to module-alias resolve order
+  Object.assign(config.aliases, getAliases(opts.aliasMode, packageRoot));
+
+  return config;
+};

--- a/modules/dev-tools/config/webpack.config.js
+++ b/modules/dev-tools/config/webpack.config.js
@@ -22,21 +22,16 @@ const {resolve} = require('path');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const config = require('./ocular.config');
-const ALIASES = require('../node/aliases')('src');
-
 const COMMON_CONFIG = {
   mode: 'development',
 
   devServer: {
     stats: {
       warnings: false
-    },
-    quiet: true
+    }
   },
 
   resolve: {
-    alias: ALIASES
   },
 
   devtool: 'inline-source-maps',
@@ -65,7 +60,7 @@ const MAIN_FIELDS = {
   es5: ['main']
 };
 
-function getEntryPoints(key) {
+function getEntryPoints(key, config) {
   let entry = config.entry[key] || {};
   if (typeof entry === 'string') {
     entry = {[key]: entry};
@@ -77,14 +72,18 @@ function getEntryPoints(key) {
 }
 
 // Replace the entry point for webpack-dev-server
-module.exports = (env = {}) => {
+module.exports = (env = {}, opts = {}) => {
+  const config = require('./ocular.config')(opts);
+
+  COMMON_CONFIG.resolve.alias = config.aliases;
+
   switch (env.mode) {
 
   case 'size':
     return Object.assign({}, COMMON_CONFIG, {
       mode: 'production',
 
-      entry: getEntryPoints('size'),
+      entry: getEntryPoints('size', config),
 
       resolve: Object.assign({}, COMMON_CONFIG.resolve, {
         mainFields: MAIN_FIELDS[env.dist] || MAIN_FIELDS.esm
@@ -99,7 +98,7 @@ module.exports = (env = {}) => {
     return Object.assign({}, COMMON_CONFIG, {
       mode: 'production',
 
-      entry: getEntryPoints('size'),
+      entry: getEntryPoints('size', config),
 
       devtool: false,
 
@@ -111,7 +110,7 @@ module.exports = (env = {}) => {
   case 'test':
   default:
     return Object.assign({}, COMMON_CONFIG, {
-      entry: getEntryPoints(`${env.mode}-browser`)
+      entry: getEntryPoints(`${env.mode}-browser`, config)
     });
   }
 

--- a/modules/dev-tools/node/test.js
+++ b/modules/dev-tools/node/test.js
@@ -7,10 +7,9 @@ const {resolve} = require('path');
 /* global process */
 const moduleAlias = require('module-alias');
 
-const getAliases = require('./aliases');
-moduleAlias.addAliases(getAliases('src'));
-
-const config = require('../config/ocular.config');
+const getConfig = require('../config/ocular.config');
+const config = getConfig();
+moduleAlias.addAliases(config.aliases);
 
 // Browser test is opt-in by installing @probe.gl/test-utils
 let BrowserTestDriver = null;
@@ -42,8 +41,9 @@ switch (mode) {
 
   case 'cover':
   case 'dist':
+    const distConfig = getConfig({aliasMode: 'dist'});
     // Load deck.gl itself from the dist folder
-    moduleAlias.addAliases(getAliases('dist'));
+    moduleAlias.addAliases(distConfig.aliases);
     require(resolveEntry('test')); // Run the tests
     break;
 

--- a/modules/dev-tools/scripts/print-config.sh
+++ b/modules/dev-tools/scripts/print-config.sh
@@ -5,7 +5,7 @@
 
 CONFIG_NAME=$1
 
-node -e "let config = require('ocular-dev-tools/config/ocular.config')$CONFIG_NAME;\
+node -e "let config = require('ocular-dev-tools/config/ocular.config')()$CONFIG_NAME;\
 if (typeof config !== 'string') {\
   config = JSON.stringify(config);\
 }\


### PR DESCRIPTION
By default, package root is assumed to be the current working directory. This change allows repos to import webpack config/aliases etc. from a directory other than root.