### PR TITLE
publish: force publish all monorepo packages with exact dependencies

### DIFF
--- a/modules/dev-tools/CHANGELOG.md
+++ b/modules/dev-tools/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG (ocular-dev-tools)
 
+## v0.0.17
+- Monorepo publish now force publishes all packages, and uses exact dependencies
+
 ## v0.0.16
 - Update lint script (#121)
 - update publish script for unirepo (#122)

--- a/modules/dev-tools/scripts/publish.sh
+++ b/modules/dev-tools/scripts/publish.sh
@@ -17,11 +17,11 @@ if [ -d "modules" ]; then
     "beta")
       # npm-tag argument: npm publish --tag <beta>
       # cd-version argument: increase <prerelease> version
-      lerna publish --npm-tag beta --cd-version prerelease
+      lerna publish --force-publish --exact --npm-tag beta --cd-version prerelease
       ;;
 
     "prod")
-      lerna publish --cd-version patch
+      lerna publish --force-publish --exact --cd-version patch
       ;;
 
     *)


### PR DESCRIPTION
While trying to stabilize deck.gl, I have found myself completely unable to control luma.gl dependencies. 

I cannot go back to a stable/predictable version of deck.gl even if I pin down all luma dependencies in deck as yarn will still pull in later versions, and the mismatched version names make it very hard to see at a glance if whatever got installed can be expected to work. 

Hopefully this change will provide the necessary control.