### PR TITLE
Configurable example template

### DIFF
--- a/modules/gatsby/src/components/layout/header.jsx
+++ b/modules/gatsby/src/components/layout/header.jsx
@@ -54,7 +54,7 @@ import {Link} from 'react-router-dom';
 function hasExamples(props) {
   const {config = {}} = props;
   const {EXAMPLES} = config;
-  return !(EXAMPLES.length === 0 || EXAMPLES[0].title === 'none');
+  return EXAMPLES.length > 0;
 }
 
 function HeaderLink({to, href, label, classnames}) {

--- a/modules/gatsby/src/components/layout/top-level-layout.jsx
+++ b/modules/gatsby/src/components/layout/top-level-layout.jsx
@@ -112,7 +112,7 @@ export default class Layout extends React.Component {
           />
         );
 
-      case 'examples':
+      case 'examples': {
         const {EXAMPLES} = config;
 
         const examplesTOC = [
@@ -122,17 +122,15 @@ export default class Layout extends React.Component {
           }
         ];
 
+        // eslint-disable-next-line
         for (const example of EXAMPLES) {
-          // ignore empty list placeholder (makes graphql queryies not fail)
-          if (example.title !== 'none') {
-            const exampleEntry = Object.assign(
-              {
-                entry: example.title
-              },
-              example
-            );
-            examplesTOC[0].entries.push(exampleEntry);
-          }
+          const exampleEntry = Object.assign(
+            {
+              entry: example.title
+            },
+            example
+          );
+          examplesTOC[0].entries.push(exampleEntry);
         }
 
         return (
@@ -141,9 +139,10 @@ export default class Layout extends React.Component {
             slug={pageContext.slug}
           />
         );
+      }
 
       default:
-        console.warn(`Unknown toc type ${pageContext.toc}`);
+        console.warn(`Unknown toc type ${pageContext.toc}`); // eslint-disable-line
         return null;
     }
   }

--- a/modules/gatsby/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby/src/gatsby-config/get-gatsby-config.js
@@ -20,10 +20,7 @@ module.exports = function getGatsbyConfig(config) {
     PROJECT_TYPE: config.PROJECT_TYPE || '',
     PROJECT_DESC: config.PROJECT_DESC || '',
     HOME_HEADING: config.HOME_HEADING || '',
-    EXAMPLES:
-      config.EXAMPLES && config.EXAMPLES.length
-        ? config.EXAMPLES
-        : [{title: 'none', path: 'none'}],
+    EXAMPLES: config.EXAMPLES || [],
     HOME_BULLETS:
       config.HOME_BULLETS && config.HOME_BULLETS.length
         ? config.HOME_BULLETS

--- a/modules/gatsby/src/gatsby-node/create-example-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-example-pages.js
@@ -40,8 +40,8 @@ function getExampleThumbnails({ allFile, allImageSharp }) {
   return pathLookup;
 }
 
-function createExamplePages(EXAMPLES, thumbnailsPublicUrls = {}, createPage) {
-  if (EXAMPLES.length === 0 || EXAMPLES[0].title === 'none') {
+function createExampleGalleryPage(EXAMPLES, thumbnailsPublicUrls = {}, createPage) {
+  if (EXAMPLES.length === 0) {
     return;
   }
   // matches public urls to paths of images
@@ -58,7 +58,9 @@ function createExamplePages(EXAMPLES, thumbnailsPublicUrls = {}, createPage) {
       examples: examplesWithImage
     }
   });
+}
 
+function createIndividualExamplePages(EXAMPLES, createPage) {
   EXAMPLES.forEach(example => {
     const exampleName = example.title;
 
@@ -67,9 +69,12 @@ function createExamplePages(EXAMPLES, thumbnailsPublicUrls = {}, createPage) {
       `Creating example page ${JSON.stringify(example)}`
     )();
 
+    const {ocularConfig} = global;
+    const exampleComponentUrl = (ocularConfig && ocularConfig.EXAMPLE_TEMPLATE_URL) || EXAMPLE_PAGE;
+
     createPage({
       path: example.path,
-      component: EXAMPLE_PAGE,
+      component: exampleComponentUrl,
       context: {
         slug: exampleName,
         toc: 'examples'
@@ -127,7 +132,8 @@ module.exports = function prepareExamplePages({ graphql, actions }) {
       // build a lookup map that matches relative paths of images with their public URLs
       const thumbnailsPublicUrls = getExampleThumbnails(result.data);
       // If the no examples marker, return without creating pages
-      createExamplePages(EXAMPLES, thumbnailsPublicUrls, createPage);
+      createExampleGalleryPage(EXAMPLES, thumbnailsPublicUrls, createPage);
+      createIndividualExamplePages(EXAMPLES, createPage);
     })
     .catch(error => {
       log.log(

--- a/modules/gatsby/src/gatsby-node/create-pages.js
+++ b/modules/gatsby/src/gatsby-node/create-pages.js
@@ -2,7 +2,7 @@ const path = require('path');
 const assert = require('assert');
 
 const { log, COLOR } = require('../utils/log');
-const prepareExamplePages = require('./create-example-pages');
+const createExamplePages = require('./create-example-pages');
 // PATHS TO REACT PAGES
 const INDEX_PAGE = path.resolve(__dirname, '../templates/index.jsx');
 const SEARCH_PAGE = path.resolve(__dirname, '../templates/search.jsx');
@@ -227,7 +227,7 @@ module.exports = function createPages({ graphql, actions }, pluginOptions) {
 
   let examplesPromise;
   if (examplePages) {
-    examplesPromise = prepareExamplePages({ graphql, actions });
+    examplesPromise = createExamplePages({ graphql, actions });
   }
 
   let searchPromise;


### PR DESCRIPTION
# Fixes #125  

The component registry we use to configure website does not work during static page generation. 

Being able to redefine the page templates seems like a viable alternative route.

If we agree on this approach, we should probably make all templates overridable.