### PR TITLE
Fix build error when package.json is missing

### DIFF
--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -28,10 +28,12 @@ build_monorepo() {
   fi
 
   for D in ${MODULES}; do (
-    echo -e "\033[1mBuilding modules/$D\033[0m"
-    cd $D
-    build_module
-    echo ""
+    if [ -e "${D}/package.json" ]; then
+      echo -e "\033[1mBuilding modules/$D\033[0m"
+      cd $D
+      build_module
+      echo ""
+    fi
   ); done
 }
 


### PR DESCRIPTION
A sub directory under modules/ may be missing package.json if
- The submodule is not intended to be published
- The submodule does not exist on the current git branch but not deleted upon switching because it contains ignored files (dist, node_modules, etc.)