### PR TITLE
Remove hard reference of reify

### DIFF
--- a/modules/dev-tools/node/test.js
+++ b/modules/dev-tools/node/test.js
@@ -1,7 +1,6 @@
 // Launch script for various Node test configurations
 
 // Enables ES2015 import/export in Node.js
-require('reify');
 const {resolve} = require('path');
 
 /* global process */

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -60,11 +60,9 @@
     "webpack-dev-server": "^3.1.14"
   },
   "devDependencies": {
-    "@probe.gl/test-utils": "^3.0.0",
-    "reify": "^0.18.1"
+    "@probe.gl/test-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "@probe.gl/test-utils": "^3.0.0",
-    "reify": "^0.18.1"
+    "@probe.gl/test-utils": "^3.0.0"
   }
 }

--- a/modules/dev-tools/scripts/test.sh
+++ b/modules/dev-tools/scripts/test.sh
@@ -10,7 +10,7 @@ MODE=$1
 MODULE_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 
 run_test_script() {
-  node $MODULE_DIR/node/test.js $1
+  BABEL_ENV=test node $MODULE_DIR/node/test.js $1
 }
 
 run_full_test() {


### PR DESCRIPTION
- `reify` cannot be installed as a dependency of ocular-dev-tools, because [reification only applies to modules in packages that explicitly depend on the reify package](https://www.npmjs.com/package/reify#usage).
- `reify` directly conflicts with `@babel/register`. The latter is required when testing React components.

Ultimately, the repo that uses this module should decide which (or none) of the require hooks to use.