### PR TITLE
Fix broken github link and getting started link for loaders.gl

### DIFF
--- a/modules/gatsby/src/components/hero.jsx
+++ b/modules/gatsby/src/components/hero.jsx
@@ -22,7 +22,7 @@ export default class Hero extends Component {
         <div className="container">
           <h1>{config.PROJECT_NAME}</h1>
           <p>{config.PROJECT_DESC}</p>
-          <Link to="/docs/" className="btn">
+          <Link to="/docs/get-started" className="btn">
             GET STARTED
           </Link>
         </div>

--- a/modules/gatsby/src/components/site-query.jsx
+++ b/modules/gatsby/src/components/site-query.jsx
@@ -4,7 +4,7 @@
 
 // because this is a StaticQuery it needs to be in the local tree so that its graphQl can be
 // run by gatsby. Rather, a file of the same name must have the same query in the local tree.
-// During the init process, ocular copies this file over to the local tree. 
+// During the init process, ocular copies this file over to the local tree.
 
 
 import React from 'react';
@@ -18,6 +18,7 @@ const QUERY = graphql`
         PROJECT_NAME
         PROJECT_TYPE
         PROJECT_DESC
+        PROJECT_URL
         HOME_HEADING
         HOME_BULLETS {
           text


### PR DESCRIPTION
For https://github.com/uber-web/loaders.gl/issues/194

Add PROJECT_URL to site query to fix broken github links.  
Add deeper link to getting started docs from button on hero page.