### PR TITLE
Do not add all files when linting

### DIFF
--- a/modules/dev-tools/scripts/lint.sh
+++ b/modules/dev-tools/scripts/lint.sh
@@ -53,9 +53,6 @@ case $MODE in
           fi
       done
     fi
-
-    # add changes to commit
-    git add .
     ;;
 
   "fix")


### PR DESCRIPTION
This makes for a very unintuitive workflow where changes that have nothing to do with the actual code can be added as a result of linting.

If this is preferred as a simple choice of ocular, then I can try to add a flag/option to disable rather than remove it.