### PR TITLE
Generate table of contents

### DIFF
--- a/modules/gatsby/bin/ocular.js
+++ b/modules/gatsby/bin/ocular.js
@@ -118,23 +118,10 @@ const commands = {
 
         result.websiteFolder = process.env.PWD;
         execSync('mkdir -p src/components static/images styles');
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> final round of changes following session with Isaac
 
         const CURRENT_PACKAGE_JSON = require(`${DIR_PATH}/package.json`)
 
         let license = CURRENT_PACKAGE_JSON.license;
-<<<<<<< HEAD
-=======
-        
-        let license = PACKAGE_JSON.license;
-        PACKAGE_JSON.name = slug(result.name);
-        PACKAGE_JSON.description = result.desc;
->>>>>>> more fixes to init process
-=======
->>>>>>> final round of changes following session with Isaac
 
         // PACKAGE_JSON.scripts = {
         //   clean: 'rm -rf ../docs/*{.js,.css,index.html,appcache,fonts,images}',

--- a/modules/gatsby/bin/ocular.js
+++ b/modules/gatsby/bin/ocular.js
@@ -118,10 +118,17 @@ const commands = {
 
         result.websiteFolder = process.env.PWD;
         execSync('mkdir -p src/components static/images styles');
+<<<<<<< HEAD
 
         const CURRENT_PACKAGE_JSON = require(`${DIR_PATH}/package.json`)
 
         let license = CURRENT_PACKAGE_JSON.license;
+=======
+        
+        let license = PACKAGE_JSON.license;
+        PACKAGE_JSON.name = slug(result.name);
+        PACKAGE_JSON.description = result.desc;
+>>>>>>> more fixes to init process
 
         // PACKAGE_JSON.scripts = {
         //   clean: 'rm -rf ../docs/*{.js,.css,index.html,appcache,fonts,images}',

--- a/modules/gatsby/bin/ocular.js
+++ b/modules/gatsby/bin/ocular.js
@@ -119,16 +119,22 @@ const commands = {
         result.websiteFolder = process.env.PWD;
         execSync('mkdir -p src/components static/images styles');
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> final round of changes following session with Isaac
 
         const CURRENT_PACKAGE_JSON = require(`${DIR_PATH}/package.json`)
 
         let license = CURRENT_PACKAGE_JSON.license;
+<<<<<<< HEAD
 =======
         
         let license = PACKAGE_JSON.license;
         PACKAGE_JSON.name = slug(result.name);
         PACKAGE_JSON.description = result.desc;
 >>>>>>> more fixes to init process
+=======
+>>>>>>> final round of changes following session with Isaac
 
         // PACKAGE_JSON.scripts = {
         //   clean: 'rm -rf ../docs/*{.js,.css,index.html,appcache,fonts,images}',


### PR DESCRIPTION
This creates a script to generate a table of contents json file from the location where the documentations files are (as indicated in the ocular-config.js file)