### PR TITLE
Post styling fixes

### DIFF
--- a/modules/gatsby/package.json
+++ b/modules/gatsby/package.json
@@ -86,6 +86,7 @@
     "react-share": "^2.0.0",
     "react-twitter-widgets": "^1.7.1",
     "react-virtualized": "^9.21.0",
+    "rehype-react": "^4.0.1",
     "slug": "^0.9.3",
     "stats.js": "^0.17.0",
     "styled-components": "^4.1.0",

--- a/modules/gatsby/src/components/styled/header.js
+++ b/modules/gatsby/src/components/styled/header.js
@@ -11,11 +11,13 @@ export const Header = styled('header', ({$theme}) => ({
   height: $theme.sizing.scale1600,
   justifyContent: 'space-between',
   padding: `0 36px`,
-  position: 'fixed',
   top: 0,
   left: 0,
   width: '100%',
   userSelect: 'none',
+  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+    position: 'fixed',
+  },
   [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     position: 'static'
   }

--- a/modules/gatsby/src/components/styled/index.js
+++ b/modules/gatsby/src/components/styled/index.js
@@ -2,13 +2,30 @@
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import ChevronDown from 'baseui/icon/chevron-down'
+import ChevronDown from 'baseui/icon/chevron-down';
 import {styled} from 'baseui';
 /* eslint-disable import/prefer-default-export */
 
-// Typography 
+// Typography
 
-export {A, CodeBlock, H1, H2, H3, H4, H5, H6, InlineCode, MarkdownBody, P, Pre} from './typography';
+export {
+  A,
+  CodeBlock,
+  H1,
+  H2,
+  H3,
+  H4,
+  H5,
+  H6,
+  InlineCode,
+  MarkdownBody,
+  P,
+  Pre,
+  Table,
+  Td,
+  Th,
+  Thead
+} from './typography';
 
 // Header
 
@@ -34,56 +51,48 @@ export {
   TocEntry,
   TocLink,
   TocSubpages,
-  TocToggle,
+  TocToggle
 } from './toc';
-
 
 // top-level layoout
 
 export const BodyContainerFull = styled('div', ({$theme, ...props}) => ({
   margin: '0 auto',
-
   '.contributors': {
     maxWidth: '400px',
     margin: '100px auto 0'
   }
 }));
 
-
-export const BodyContainerToC = styled('div', ({$theme, $isTocOpen, ...props}) => ({
-  gridColumn: '2 / 3',
-  gridRow: '2 / 3',
-  width: '100%',
-  padding: $theme.sizing.scale500,
-  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
-    order: 2,
-    opacity: $isTocOpen ? 0 : 1,
-    transition: 'opacity 0.3s'
-  },
-
-  '& > div': {
-    maxWidth: $theme.breakpoints.large,
-    margin: 'auto'
-  },
-  '& p': {
-    marginBottom: $theme.sizing.scale500
-  },
-
-  '& > h1': {
-    color: $theme.colors.mono1000
-  }
-}));
+export const BodyContainerToC = styled(
+  'div',
+  ({$theme, $isTocOpen, ...props}) => ({
+    width: '100%',
+    padding: $theme.sizing.scale500,
+    [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+      gridColumn: '2 / 3',
+      gridRow: '2 / 3',
+      opacity: 1
+    },
+    [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
+      order: 2,
+      opacity: $isTocOpen ? 0 : 1,
+      transition: 'opacity 0.3s'
+    }
+  })
+);
 
 export const BodyGrid = styled('div', ({$theme, ...props}) => ({
   height: '100vh',
-  display: 'grid',
-  gridTemplateRows: '64px 1fr',
-  gridTemplateColumns: '300px 1fr',
   maxWidth: `${$theme.breakpoints.large}px`,
+  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+    display: 'grid',
+    gridTemplateRows: '64px 1fr',
+    gridTemplateColumns: '300px 1fr'
+  },
   [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     display: 'flex',
-    flexDirection: 'column',
-    height: 'inherit'
+    flexDirection: 'column'
   }
 }));
 
@@ -111,12 +120,8 @@ export const ExampleCard = styled('div', ({$theme, ...props}) => ({
   border: $theme.borders.border300,
   cursor: 'pointer',
   margin: $theme.sizing.scale400,
-  padding: `${$theme.sizing.scale700} ${$theme.sizing.scale600} ${
-    $theme.sizing.scale700
-  } ${$theme.sizing.scale600}`,
-  transition: `background ${$theme.animation.timing400} border-color ${
-    $theme.animation.timing400
-  }`,
+  padding: `${$theme.sizing.scale700} ${$theme.sizing.scale600} ${$theme.sizing.scale700} ${$theme.sizing.scale600}`,
+  transition: `background ${$theme.animation.timing400} border-color ${$theme.animation.timing400}`,
   transitionTimingFunction: $theme.animation.easeInOutCurve,
   '&:hover': {
     background: $theme.colors.mono200,

--- a/modules/gatsby/src/components/styled/toc.js
+++ b/modules/gatsby/src/components/styled/toc.js
@@ -50,10 +50,15 @@ export const TocSubpages = styled('ul', ({$height, ...props}) => ({
 }));
 
 export const TocContainer = styled('div', ({$theme, $isTocOpen, ...props}) => ({
-  gridColumn: '1 / 2',
-  gridRow: '2 / 3',
-  borderRight: `1px solid ${$theme.colors.mono500}`,
-  overflow: 'scroll',
+  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+    borderRight: `1px solid ${$theme.colors.mono500}`,
+    gridColumn: '1 / 2',
+    gridRow: '2 / 3',
+    maxHeight: 'unset',
+    opacity: 1,
+    overflow: 'scroll',
+    transform: 'translateY(0)'
+  },
   [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     // order: 3,
     borderRight: 'none',
@@ -77,7 +82,6 @@ const StyledTocToggle = styled('div', ({$theme}) => ({
   fontFamily: 'Uber Move',
   background: $theme.colors.mono1000,
   color: $theme.colors.mono100,
-  display: 'flex',
   alignItems: 'center',
   padding: '18px 24px',
   position: 'sticky',
@@ -86,6 +90,9 @@ const StyledTocToggle = styled('div', ({$theme}) => ({
   zIndex: 10,
   [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
     display: 'none'
+  },
+  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
+    display: 'flex',
   }
 }));
 

--- a/modules/gatsby/src/components/styled/typography.js
+++ b/modules/gatsby/src/components/styled/typography.js
@@ -70,3 +70,24 @@ export const CodeBlock = styled('code', ({$theme}) => ({
 export const Pre = styled('pre', ({$theme}) => ({
    backgroundColor: $theme.colors.mono200
 }));
+
+export const Table = styled('table', ({$theme}) => ({
+  ...$theme.borders.border300,
+  borderCollapse: 'collapse',
+  fontSize: '0.9em',
+  margin: `${$theme.sizing.scale800} 0`,
+  overflow: 'hidden',
+  width: '100%'
+}));
+
+export const Td = styled('td', ({$theme}) => ({
+  padding: $theme.sizing.scale400
+}));
+
+export const Th = styled('th', ({$theme}) => ({
+  ...$theme.borders.border300
+}));
+
+export const Thead = styled('thead', ({$theme}) => ({
+  boxShadow: $theme.lighting.shadow400,
+}));

--- a/modules/gatsby/src/templates/doc-page-markdown.jsx
+++ b/modules/gatsby/src/templates/doc-page-markdown.jsx
@@ -6,7 +6,24 @@ import {graphql} from 'gatsby';
 // we can consider customizing them by first importing in styled/index, then
 // giving them special parameters
 
-import {A, CodeBlock, H1, H2, H3, H4, H5, H6, InlineCode, P, Pre, MarkdownBody} from '../components/styled';
+import {
+  A,
+  CodeBlock,
+  H1,
+  H2,
+  H3,
+  H4,
+  H5,
+  H6,
+  InlineCode,
+  P,
+  Pre,
+  MarkdownBody,
+  Table,
+  Td,
+  Th,
+  Thead
+} from '../components/styled';
 
 const CustomLinkWrapper = relativeLinks => {
   const CustomLink = ({href, ...props}) => {
@@ -22,23 +39,26 @@ const CustomLinkWrapper = relativeLinks => {
 
 const CustomPre = props => {
   // the point of this component is to distinguish styling of inline <code /> elements
-  // with code blocks (ie <pre><code>...</code></pre>). 
+  // with code blocks (ie <pre><code>...</code></pre>).
 
   const {children, ...otherProps} = props;
-  return (<Pre {...otherProps}>
-    {
-      React.Children.map(children, child => {
+  return (
+    <Pre {...otherProps}>
+      {React.Children.map(children, child => {
         // this means a child of this <pre> element is a <code> element, or <code> element styled
         // by Styletron
-        if (child.type === 'code' || child.type.displayName === 'Styled(code)') {
+        if (
+          child.type === 'code' ||
+          child.type.displayName === 'Styled(code)'
+        ) {
           return <CodeBlock {...child.props} />;
         }
         // else we just clone the element as is
         return React.cloneElement(child);
-      })
-    }
-  </Pre>);
-}
+      })}
+    </Pre>
+  );
+};
 
 // Query for the markdown doc by slug
 // (Note: We could just search the allMarkdown from WebsiteConfig ourselves)
@@ -70,8 +90,8 @@ export default class DocTemplate extends React.Component {
     // detect an <h1> element, we will replace it with an H1 custom component. In that case
     // H1 is just a styled version of h1. However, with that process we can implement custom
     // logic. For instance we can rewrite the contents of the link on the fly (CustomLinkWrapper).
-    // we can style differently code tags which are within or without a <pre> element. And we can 
-    // add many more such custom components as needed. 
+    // we can style differently code tags which are within or without a <pre> element. And we can
+    // add many more such custom components as needed.
     const renderAst = new rehypeReact({
       createElement: React.createElement,
       components: {
@@ -84,6 +104,10 @@ export default class DocTemplate extends React.Component {
         p: P,
         pre: CustomPre,
         code: InlineCode,
+        table: Table,
+        td: Td,
+        th: Th,
+        thead: Thead,
         a: CustomLinkWrapper(relativeLinks)
       }
     }).Compiler;

--- a/modules/gatsby/yarn.lock
+++ b/modules/gatsby/yarn.lock
@@ -454,6 +454,13 @@
   dependencies:
     core-js "^2.5.7"
 
+"@mapbox/hast-util-table-cell-style@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
+  integrity sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==
+  dependencies:
+    unist-util-visit "^1.3.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4154,6 +4161,18 @@ hast-to-hyperscript@^5.0.0:
     unist-util-is "^2.0.0"
     web-namespaces "^1.1.2"
 
+hast-to-hyperscript@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-7.0.2.tgz#e9237c88c6069999ad38aec847fefc296f484c4c"
+  integrity sha512-NBMMst0hkDR21uSH75m9W2DkljBrLoMQEhGiLMLNij4HIzEDJMC1UG+CFR6EAjHi2zs3NHBoaAHJOHxftoIN2g==
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+    style-to-object "^0.2.1"
+    unist-util-is "^3.0.0"
+    web-namespaces "^1.1.2"
+
 hast-util-from-parse5@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-4.0.2.tgz#b7164a7ffc88da4f751dc7c2f801ff8d7c143bab"
@@ -7200,6 +7219,13 @@ property-information@^4.0.0:
   dependencies:
     xtend "^4.0.1"
 
+property-information@^5.0.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.2.2.tgz#20555eafd2296278a682e5a51d5123e7878ecc30"
+  integrity sha512-N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==
+  dependencies:
+    xtend "^4.0.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -7655,6 +7681,14 @@ registry-url@^3.0.3:
   integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
+
+rehype-react@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-react/-/rehype-react-4.0.1.tgz#fcb79e99b49ee056cfc266c4992ecfae939e8efa"
+  integrity sha512-xg6PZHqWJLTBQM6ECvzWEZhVqRpbxrx8eAPaWQAoRK7v9lkAuBelBym3AVUvGRzlQsZky9MdKrDzyYTTm1cejQ==
+  dependencies:
+    "@mapbox/hast-util-table-cell-style" "^0.1.3"
+    hast-to-hyperscript "^7.0.0"
 
 reify@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION
This PR addresses styling issues where the style in production (gatsby build) is different from the style in development (gatsby develop).

we can't guarantee precedence for whatever styling is in a media query. 
so, in a code like this:

```
styled('div', ({$theme}) => ({
  height: '20px',
  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
    height: '40px',
  }
}));
```
we can't predict the actual height if the media query is triggered. it may be 20px or 40px and it may be different in prod or dev.

The solution is to put all statements that could be affected by a media query in an opposite, mutually exclusive media query, ie:

```
styled('div', ({$theme}) => ({
  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
    height: '20px',
  }
  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
    height: '40px',
  }
}));
```
now we are sure that the this element will either be 20px high in large displays, and 40px high in small displays. 

In addition, this PR introduces a styled table with margin before and after and styling consistent with baseweb.

![Screen Shot 2019-08-19 at 7 18 59 PM](https://user-images.githubusercontent.com/9727630/63312371-388b4b00-c2b6-11e9-8644-5c583d6a0364.png)

 