### PR TITLE
es6 build: stricter targets to eliminate async/await transformations

### DIFF
--- a/modules/dev-tools/config/babel.config.js
+++ b/modules/dev-tools/config/babel.config.js
@@ -1,10 +1,14 @@
-const TARGETS = {
-  chrome: '60',
-  edge: '15',
-  firefox: '53',
-  ios: '10.3',
-  safari: '10.1',
-  node: '8'
+// The goal of the `es6` target is a very clean build (minimally trannsformed) that runs on recent browsers only.
+// In particular, it does not transform async/await constructs, which is very helpful when debugging
+// Because of this, we only try to support ~1 year old browsers + Node LTS
+// Including older versions dramatically increases the number of transforms
+const ES6_TARGETS = {
+  chrome: '64', // Released: 2018-Jan-24, https://en.wikipedia.org/wiki/Google_Chrome_version_history
+  edge: '18', // Released: 2018-Nov-13, https://en.wikipedia.org/wiki/Microsoft_Edge
+  firefox: '60', // Released: 2018-May-9, https://en.wikipedia.org/wiki/Firefox_version_history
+  safari: '12', // Released: 2018-09-07 (OSX Mojave) - https://en.wikipedia.org/wiki/Safari_version_history
+  ios: '12', // Track Safari
+  node: '8' // Node 8 is LTS until December 31, 2019.
 };
 
 const COMMON_CONFIG = {
@@ -38,7 +42,10 @@ const ENV_CONFIG = {
     presets: [
       [ '@babel/env', {
         targets: TARGETS,
-        modules: false
+        modules: false,
+	exclude: [
+	  "@babel/plugin-transform-regenerator"
+	]
       }]
     ],
     plugins: [


### PR DESCRIPTION
The current set of targets include too many transforms. In particular, `async/await` gets transformed and generator runtime gets included which completely defeats the clean `async` debugging experience in Chrome.

At this point, the goal is to get rid of 
```
  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
```

As can be seen, additional plugin reduction will not be possible until end of year when Node 8 ends LTS.

After the change the following plugins are picked:
```
  transform-template-literals { "ios":"12", "safari":"12" }
  transform-function-name { "edge":"18" }
  transform-dotall-regex { "edge":"18", "firefox":"60", "node":"8" }
  proposal-async-generator-functions { "edge":"18", "node":"8" }
  proposal-object-rest-spread { "edge":"18", "node":"8" }
  proposal-unicode-property-regex { "edge":"18", "firefox":"60", "node":"8" }
  proposal-json-strings { "chrome":"64", "edge":"18", "firefox":"60", "node":"8" }
  proposal-optional-catch-binding { "chrome":"64", "edge":"18", "node":"8" }
  transform-named-capturing-groups-regex { "edge":"18", "firefox":"60", "node":"8" }
```

Before the change

```
  transform-template-literals { "ios":"10.3", "safari":"10.1" }
  transform-function-name { "edge":"15" }
  transform-dotall-regex { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
  transform-parameters { "edge":"15" }
  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
  proposal-async-generator-functions { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  proposal-object-rest-spread { "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  proposal-unicode-property-regex { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  proposal-json-strings { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  proposal-optional-catch-binding { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
  transform-named-capturing-groups-regex { "chrome":"60", "edge":"15", "firefox":"53", "ios":"10.3", "node":"8", "safari":"10.1" }
```
