### PR TITLE
fix layout issues (see luma.gl)

### DIFF
--- a/modules/gatsby/src/components/layout/docs-header.jsx
+++ b/modules/gatsby/src/components/layout/docs-header.jsx
@@ -32,7 +32,7 @@ import ControlledHeader, {
 // 2 - Header, which won't and just maintain its own state.
 // both components are wrappers around ControlledHeader.
 
-export default class Header extends Component {
+export default class DocsHeader extends Component {
   constructor(props) {
     super(props);
     // we need to know the number of links before render.
@@ -40,40 +40,19 @@ export default class Header extends Component {
     // some of the links which are hardcoded should come from configuration
     // TODO - let's create the links server side, then pass them to the template as props.
     this.state = {
-      collapsed: true,
       links: generateHeaderLinks(props)
     };
-    this.handleClick = this.handleClick.bind(this);
-  }
-  handleClick() {
-    this.setState({collapsed: !this.state.collapsed});
   }
 
-  // note that rn, we don't render stars per design, but this could change
-  renderStars() {
-    const {config} = this.props;
-    if (config.PROJECT_TYPE === 'github') {
-      return (
-        <GithubStars project={`${config.PROJECT_ORG}/${config.PROJECT_NAME}`} />
-      );
-    }
+  renderHeader() {
+    const {links} = this.state;
 
-    return null;
+    return <ControlledHeader links={links} {...this.props} />;
   }
 
   render() {
-    const {links, collapsed} = this.state;
-    return (
-      <ControlledHeader
-        {...this.props}
-        links={links}
-        isLinksMenuOpen={false}
-        isProjectsMenuOpen={!collapsed}
-        toggleProjectsMenu={this.handleClick}
-        toggleLinksMenu={() => {}}
-      />
-    );
+    return this.renderHeader();
   }
 }
 
-Header.propTypes = propTypes;
+DocsHeader.propTypes = propTypes;

--- a/modules/gatsby/src/components/layout/header.component.jsx
+++ b/modules/gatsby/src/components/layout/header.component.jsx
@@ -1,0 +1,157 @@
+/* eslint-disable react/no-array-index-key */
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import GithubIcon from 'react-icons/lib/go/mark-github';
+
+import {
+  HamburgerMenu,
+  Header as StyledHeader,
+  HeaderA,
+  HeaderLink as StyledLink,
+  HeaderLinksBlock,
+  HeaderLinkContainer,
+  HeaderLogo,
+  HeaderMenuBlock,
+  HeaderMenu,
+  HeaderMenuLink
+} from '../styled/';
+
+import GithubStars from '../github/github-stars.jsx';
+
+export const propTypes = {
+  config: PropTypes.object.isRequired
+};
+
+function GithubLink() {
+  return (
+    <div className="github-link">
+      <span>Github</span>
+      {/* <GithubIcon style={{marginLeft: '0.5rem', display: 'inline'}} /> */}
+    </div>
+  );
+}
+
+function HeaderLink({to, href, label}) {
+  if (to) {
+    return <StyledLink to={to}>{label}</StyledLink>;
+  }
+  return <HeaderA href={href}>{label}</HeaderA>;
+}
+
+/**
+ * Generate all the links in the header.
+ * @param  {Object} props Input props which includes site config.
+ * @return {Array}  Array of link object ({label, to, href, classnames})
+ */
+export function generateHeaderLinks(props) {
+  const {config = {}} = props;
+
+  const exampleLink = config.EXAMPLES &&
+    config.EXAMPLES.length > 0 && {label: 'Examples', to: '/examples'};
+
+  const githubLink = config.PROJECT_TYPE === 'github' && {
+    classnames: 'z',
+    href: `https://github.com/${config.PROJECT_ORG}/${config.PROJECT_NAME}`,
+    label: <GithubLink />
+  };
+
+  const links = [
+    exampleLink,
+    {label: 'Documentation', to: '/docs'},
+    {label: 'Search', to: '/search'},
+    {label: 'Blog', href: 'https://medium.com/vis-gl'},
+    githubLink
+  ];
+
+  if (config.ADDITIONAL_LINKS && config.ADDITIONAL_LINKS.length > 0) {
+    config.ADDITIONAL_LINKS.map(link => ({...link, label: link.name})).forEach(
+      link => {
+        if (link.index !== undefined) {
+          links.splice(link.index, 0, link);
+        } else {
+          links.push(link);
+        }
+      }
+    );
+  }
+
+  return links.filter(Boolean);
+}
+
+const ControlledHeader = ({
+  links,
+  config = {},
+  isSmallScreen,
+  isLinksMenuOpen,
+  isProjectsMenuOpen,
+  toggleLinksMenu,
+  toggleProjectsMenu
+}) => {
+  const {PROJECT_NAME, PROJECTS = []} = config;
+  return (
+    <StyledHeader>
+      <HeaderMenuBlock>
+        {PROJECTS.length ? (
+          <HamburgerMenu onClick={toggleProjectsMenu} />
+        ) : null}
+        <HeaderLogo href="/">{PROJECT_NAME}</HeaderLogo>
+        <HeaderMenu $collapsed={!isProjectsMenuOpen} $nbItems={PROJECTS.length}>
+          {PROJECTS.map(({name, url}) => (
+            <HeaderMenuLink key={`menulink-${name}`} href={url}>
+              {name}
+            </HeaderMenuLink>
+          ))}
+        </HeaderMenu>
+      </HeaderMenuBlock>
+      <HeaderLinksBlock
+        style={{
+          maxHeight:
+            isSmallScreen && isLinksMenuOpen
+              ? `${4 * links.length}rem`
+              : undefined
+        }}
+      >
+        {/* If the no examples marker, return without creating pages */}
+        {links.map((link, index) => (
+          <HeaderLinkContainer key={`link-${index}`}>
+            <HeaderLink {...link} />
+          </HeaderLinkContainer>
+        ))}
+        {/* this.renderStars() */}
+
+        <div
+          className="menu-toggle"
+          onClick={() => {
+            toggleLinksMenu(!isLinksMenuOpen);
+          }}
+        >
+          {/* currently, this isn't rendered. but this is in place if we want to have
+          the links on the header collapsible for small displays */}
+          <i className={`icon icon-${isLinksMenuOpen ? 'close' : 'menu'}`} />
+        </div>
+      </HeaderLinksBlock>
+    </StyledHeader>
+  );
+};
+
+export default ControlledHeader;

--- a/modules/gatsby/src/components/layout/header.jsx
+++ b/modules/gatsby/src/components/layout/header.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,6 +36,9 @@ import {
   HeaderMenu,
   HeaderMenuLink
 } from '../styled/';
+import {navigate} from 'gatsby';
+import {Search} from 'baseui/icon';
+import {Input} from 'baseui/input';
 
 import GithubStars from '../github/github-stars.jsx';
 
@@ -98,6 +102,94 @@ function generateHeaderLinks(props) {
   return links.filter(Boolean);
 }
 
+const ControlledHeader = ({
+  links,
+  config = {},
+  isSmallScreen,
+  isLinksMenuOpen,
+  isProjectsMenuOpen,
+  toggleLinksMenu,
+  toggleProjectsMenu
+}) => {
+  const {PROJECT_NAME, PROJECTS = []} = config;
+  return (
+    <StyledHeader>
+      <HeaderMenuBlock>
+        {PROJECTS.length ? (
+          <HamburgerMenu onClick={toggleProjectsMenu} />
+        ) : null}
+        <HeaderLogo href="/">{PROJECT_NAME}</HeaderLogo>
+        <HeaderMenu $collapsed={!isProjectsMenuOpen} $nbItems={PROJECTS.length}>
+          {PROJECTS.map(({name, url}) => (
+            <HeaderMenuLink key={`menulink-${name}`} href={url}>
+              {name}
+            </HeaderMenuLink>
+          ))}
+        </HeaderMenu>
+      </HeaderMenuBlock>
+      <HeaderLinksBlock
+        style={{
+          maxHeight:
+            isSmallScreen && isLinksMenuOpen
+              ? `${4 * links.length}rem`
+              : undefined
+        }}
+      >
+        {/* If the no examples marker, return without creating pages */}
+        {links.map((link, index) => (
+          <HeaderLinkContainer key={`link-${index}`}>
+            <HeaderLink {...link} />
+          </HeaderLinkContainer>
+        ))}
+        {/* this.renderStars() */}
+
+        <div
+          className="menu-toggle"
+          onClick={() => {
+            toggleLinksMenu(!isLinksMenuOpen);
+          }}
+        >
+          {/* currently, this isn't rendered. but this is in place if we want to have
+          the links on the header collapsible for small displays */}
+          <i className={`icon icon-${isLinksMenuOpen ? 'close' : 'menu'}`} />
+        </div>
+      </HeaderLinksBlock>
+    </StyledHeader>
+  );
+};
+
+// we are exposing 2 header components. 
+// 1 - DocsHeader, which will update the state of the top level layout.
+//   we need to expose whether the menu is toggled or not because it could
+//   affect how TOC is displayed in smaller screens. 
+// 2 - Header, which won't and just maintain its own state.
+// both components are wrappers around ControlledHeader.
+
+export class DocsHeader extends Component {
+  constructor(props) {
+    super(props);
+    // we need to know the number of links before render.
+    // this is not an ideal solution.
+    // some of the links which are hardcoded should come from configuration
+    // TODO - let's create the links server side, then pass them to the template as props.
+    this.state = {
+      links: generateHeaderLinks(props)
+    };
+  }
+
+  renderHeader() {
+    const {links} = this.state;
+
+    return <ControlledHeader links={links} {...this.props} />;
+  }
+
+  render() {
+    return this.renderHeader();
+  }
+}
+
+DocsHeader.propTypes = propTypes;
+
 export default class Header extends Component {
   constructor(props) {
     super(props);
@@ -111,11 +203,11 @@ export default class Header extends Component {
     };
     this.handleClick = this.handleClick.bind(this);
   }
-
   handleClick() {
     this.setState({collapsed: !this.state.collapsed});
   }
 
+  // note that rn, we don't render stars per design, but this could change
   renderStars() {
     const {config} = this.props;
     if (config.PROJECT_TYPE === 'github') {
@@ -127,65 +219,18 @@ export default class Header extends Component {
     return null;
   }
 
-  renderHeader() {
-    // TODO/ib - replace data with config
-    const {
-      config = {},
-      pathname,
-      isSmallScreen,
-      isMenuOpen,
-      opacity
-    } = this.props;
-    const {PROJECT_NAME, PROJECTS = []} = config;
-
-    const {links} = this.state;
-
-    return (
-      <StyledHeader>
-        <HeaderMenuBlock>
-          {PROJECTS.length ? (
-            <HamburgerMenu onClick={this.handleClick} />
-          ) : null}
-          <HeaderLogo href="/">{PROJECT_NAME}</HeaderLogo>
-          <HeaderMenu
-            $collapsed={this.state.collapsed}
-            $nbItems={PROJECTS.length}
-          >
-            {PROJECTS.map(({name, url}) => (
-              <HeaderMenuLink key={name} href={url}>
-                {name}
-              </HeaderMenuLink>
-            ))}
-          </HeaderMenu>
-        </HeaderMenuBlock>
-
-        <HeaderLinksBlock
-          style={{
-            maxHeight:
-              isSmallScreen && isMenuOpen ? `${4 * links.length}rem` : undefined
-          }}
-        >
-          {/* If the no examples marker, return without creating pages */}
-          {links.map((link, index) => (
-            <HeaderLinkContainer>
-              <HeaderLink {...link} key={index} />
-            </HeaderLinkContainer>
-          ))}
-          {/* this.renderStars() */}
-
-          <div
-            className="menu-toggle"
-            onClick={() => this.props.toggleMenu(!isMenuOpen)}
-          >
-            <i className={`icon icon-${isMenuOpen ? 'close' : 'menu'}`} />
-          </div>
-        </HeaderLinksBlock>
-      </StyledHeader>
-    );
-  }
-
   render() {
-    return this.renderHeader();
+    const {links, collapsed} = this.state;
+    return (
+      <ControlledHeader
+        {...this.props}
+        links={links}
+        isLinksMenuOpen={false}
+        isProjectsMenuOpen={!collapsed}
+        toggleProjectsMenu={this.handleClick}
+        toggleLinksMenu={() => {}}
+      />
+    );
   }
 }
 

--- a/modules/gatsby/src/components/layout/table-of-contents.component.jsx
+++ b/modules/gatsby/src/components/layout/table-of-contents.component.jsx
@@ -1,0 +1,148 @@
+/* eslint-disable prefer-const */
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {TocChevron, TocHeader, TocLink, TocEntry, TocSubpages} from '../styled';
+
+// sub components of the TOC
+
+// This component only creates a Link component if clicking on that Link will
+// effectively change routes. If no path is passed or if the path is not
+// usable then it just renders a div. That should not be the case
+
+const SafeLink = ({
+  active,
+  depth,
+  hasChildren,
+  isTocOpen,
+  id,
+  name,
+  path,
+  toggleEntry = () => {}
+}) => {
+  // Gatsby <Link> element emmits warning if "external" links are used
+  // "internal" links start with `/`
+  // https://github.com/gatsbyjs/gatsby/issues/11243
+  if (path && !path.startsWith('/')) {
+    path = `/${path}`; // eslint-disable-line
+  }
+
+  return (
+    <TocEntry $depth={depth} title={name} onClick={() => toggleEntry(id)}>
+      {hasChildren && <TocChevron $depth={depth} $isTocOpen={isTocOpen} />}
+      {!path || typeof path !== 'string' ? (
+        <TocHeader $depth={depth}>{name}</TocHeader>
+      ) : (
+        <TocLink $depth={depth} to={path} title={name} $active={active}>
+          {name}
+        </TocLink>
+      )}
+    </TocEntry>
+  );
+};
+
+const renderRoute = ({route, id, index, depth, tocState, toggleEntry}) => {
+  const children = route.chapters || route.entries || [];
+  const updatedId = id.concat(index);
+
+  // parts of the TOC with children
+
+  if (children.length) {
+    const name = route.title;
+    const routeInfo = tocState[updatedId];
+    return (
+      <div key={index}>
+        <SafeLink
+          depth={depth}
+          hasChildren
+          isTocOpen={routeInfo && routeInfo.height > 0}
+          id={updatedId}
+          name={name}
+          /* uncomment to have the entry act as link to its first child */
+          /* path={routeInfo && routeInfo.pathToFirstChild} */
+          toggleEntry={toggleEntry}
+        />
+        <TocSubpages $height={routeInfo && routeInfo.height}>
+          {children.map((childRoute, idx) => {
+            if (!childRoute.childMarkdownRemark) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `Missing content for entry ${idx} in chapter ${route.title}`,
+                route
+              );
+            }
+
+            return renderRoute({
+              depth: depth + 1,
+              id: updatedId,
+              index: idx,
+              route: childRoute,
+              tocState,
+              toggleEntry
+            });
+          })}
+        </TocSubpages>
+      </div>
+    );
+  }
+
+  // leaves
+
+  const remark = route.childMarkdownRemark;
+  // first syntax is toc for documentation, second is toc for examples
+  const name =
+    (remark && remark.frontmatter && remark.frontmatter.title) || route.title;
+  const target = (remark && remark.fields && remark.fields.slug) || route.path;
+  return (
+    <div key={index}>
+      <li>
+        <SafeLink
+          active={
+            tocState[updatedId] && tocState[updatedId].isSelected === true
+          }
+          depth={depth}
+          name={name}
+          path={target}
+        />
+      </li>
+    </div>
+  );
+};
+
+const ControlledToc = ({tree, tocState, toggleEntry}) => {
+  return (
+    <>
+      {tree.map((route, index) =>
+        renderRoute({
+          route,
+          index,
+          depth: 0,
+          tocState,
+          toggleEntry,
+          id: []
+        })
+      )}
+    </>
+  );
+};
+
+export default ControlledToc;

--- a/modules/gatsby/src/components/layout/table-of-contents.jsx
+++ b/modules/gatsby/src/components/layout/table-of-contents.jsx
@@ -47,7 +47,15 @@ export default class TableOfContents extends PureComponent {
     this.toggleEntry = this.toggleEntry.bind(this);
   }
 
+
+  componentDidMount() {
+    console.log('CDM');
+  }
+  componentWillUnmount() {
+    console.log('CWU');
+  }
   componentDidUpdate(prevProps) {
+    console.log('CDU');
     if (this.props.slug !== prevProps.slug) {
       const {chapters, slug} = this.props;
       const {expanded} = this.state;
@@ -79,6 +87,7 @@ export default class TableOfContents extends PureComponent {
   }
 
   render() {
+    console.log('R');
     const {chapters: tree, slug} = this.props;
 
     if (!tree) {

--- a/modules/gatsby/src/components/layout/table-of-contents.jsx
+++ b/modules/gatsby/src/components/layout/table-of-contents.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable operator-assignment */
+/* eslint-disable no-param-reassign */
+/* eslint-disable prefer-const */
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,141 +22,9 @@
 // THE SOFTWARE.
 
 import React, {PureComponent} from 'react';
-
-import {TocChevron, TocHeader, TocLink, TocEntry, TocSubpages} from '../styled';
-
-export default class TableOfContents extends PureComponent {
-  constructor(props) {
-    super(props);
-    const {slug, chapters, firstItemIsExpanded} = props;
-    const expanded = firstItemIsExpanded ? {0: true} : {};
-    const tocState = getTocState({slug, chapters, expanded});
-
-    // tocState contains the state of the TOC with information such as
-    // what is the current height of an entry?
-    // is an entry selected or is any of its children selected?
-    // expanded records whether the user manually expanded or collapsed
-    // a section of the TOC.
-    // why keep them separated? tocState get regenerated for instance
-    // when the slug changes (which may mean that some sections get expanded/collapsed)
-    // we don't want to overwrite the manual actions of the user in that case.
-    // instead, we first apply the "organic" changes of the toc, then on top of that
-    // we add the results of the user's action
-
-    this.state = {
-      tocState,
-      expanded
-    };
-    this.toggleEntry = this.toggleEntry.bind(this);
-  }
-
-
-  componentDidMount() {
-    console.log('CDM');
-  }
-  componentWillUnmount() {
-    console.log('CWU');
-  }
-  componentDidUpdate(prevProps) {
-    console.log('CDU');
-    if (this.props.slug !== prevProps.slug) {
-      const {chapters, slug} = this.props;
-      const {expanded} = this.state;
-      const tocState = getTocState({chapters, slug, expanded});
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        tocState,
-        expanded
-      });
-    }
-  }
-
-  toggleEntry(id) {
-    const {expanded, tocState} = this.state;
-    let updatedExpanded = {...expanded};
-    const entry = tocState[id];
-
-    // if this entry has been manually expanded, then we manually collapse it.
-    // else - either this entry has never been manually expanded/collapsed,
-    // or it has been manually collapsed - we expand it.
-    updatedExpanded[id] = !isOpen(entry, expanded);
-    // then we need to update the heights.
-    let updatedTocState = updateHeights({...tocState}, updatedExpanded);
-
-    this.setState({
-      tocState: updatedTocState,
-      expanded: updatedExpanded
-    });
-  }
-
-  render() {
-    console.log('R');
-    const {chapters: tree, slug} = this.props;
-
-    if (!tree) {
-      return null;
-    }
-    return (
-      <ControlledToc
-        tree={tree}
-        tocState={this.state.tocState}
-        toggleEntry={this.toggleEntry}
-      />
-    );
-  }
-}
+import ControlledToc from './table-of-contents.component';
 
 // util functions to pre-process the TOC
-
-function getTocState({chapters, slug, expanded}) {
-  // we try to generate the height of each toc entry and whether it's expanded
-  // or not based on the toc structure (chapters), whether some entries are
-  // manually expanded or not (open) and what's the current page (slug)
-
-  // there may be a lot of code but this goes very fast even for long tocs.
-
-  // one way to uniquely identify entries is by creating an id made of the
-  // index position of all of its parents and itself.
-  // ie [2, 0, 1] - 3nd chapter, 1st entry, 2nd item.
-
-  const entries = {};
-  let queue = chapters.map((chapter, i) => ({
-    ...chapter,
-    id: [i],
-    parents: []
-  }));
-  while (queue.length) {
-    const current = queue.shift();
-    const id = current.id;
-    entries[id] = {id};
-
-    const children = (current.chapters || current.entries || []).map(
-      (child, i) => ({
-        ...child,
-        id: id.concat(i),
-        parents: [...current.parents, id]
-      })
-    );
-    if (children.length) {
-      entries[id].children = children.map(c => c.id);
-    }
-    children.forEach(c => queue.push(c));
-    if (current.childMarkdownRemark) {
-      // only happens for leave nodes
-      current.parents.forEach(parent => {
-        if (current.childMarkdownRemark.fields.slug === slug) {
-          entries[parent].childIsSelected = true;
-        }
-        // currently the behavior of entries is to toggle them
-        // if we switch to using them as link to the first child (as before)
-        // we can just uncomment that line
-        // entries[parent].pathToFirstChild = current.childMarkdownRemark.fields.slug;
-      });
-      entries[id].isSelected = current.childMarkdownRemark.fields.slug === slug;
-    }
-  }
-  return updateHeights(entries, expanded);
-}
 
 function isOpen(entry, expanded) {
   // this is all the reasons why a given toc entry with children could
@@ -194,123 +65,125 @@ function updateHeights(tocEntries, expanded) {
   return tocEntries;
 }
 
-// sub components of the TOC
+function getTocState({chapters, slug, expanded}) {
+  // we try to generate the height of each toc entry and whether it's expanded
+  // or not based on the toc structure (chapters), whether some entries are
+  // manually expanded or not (open) and what's the current page (slug)
 
-// This component only creates a Link component if clicking on that Link will
-// effectively change routes. If no path is passed or if the path is not
-// usable then it just renders a div. That should not be the case
+  // there may be a lot of code but this goes very fast even for long tocs.
 
-const SafeLink = ({
-  active,
-  depth,
-  hasChildren,
-  isTocOpen,
-  id,
-  name,
-  path,
-  toggleEntry = () => {}
-}) => {
-  // Gatsby <Link> element emmits warning if "external" links are used
-  // "internal" links start with `/`
-  // https://github.com/gatsbyjs/gatsby/issues/11243
-  if (path && !path.startsWith('/')) {
-    path = `/${path}`; // eslint-disable-line
+  // one way to uniquely identify entries is by creating an id made of the
+  // index position of all of its parents and itself.
+  // ie [2, 0, 1] - 3nd chapter, 1st entry, 2nd item.
+
+  const entries = {};
+  let queue = chapters.map((chapter, i) => ({
+    ...chapter,
+    id: [i],
+    parents: []
+  }));
+  while (queue.length) {
+    const current = queue.shift();
+    const {id} = current;
+    entries[id] = {id};
+
+    const children = (current.chapters || current.entries || []).map(
+      (child, i) => ({
+        ...child,
+        id: id.concat(i),
+        parents: [...current.parents, id]
+      })
+    );
+    if (children.length) {
+      entries[id].children = children.map(c => c.id);
+    }
+    children.forEach(c => queue.push(c));
+    if (current.childMarkdownRemark) {
+      // only happens for leave nodes
+      current.parents.forEach(parent => {
+        if (current.childMarkdownRemark.fields.slug === slug) {
+          entries[parent].childIsSelected = true;
+        }
+        // currently the behavior of entries is to toggle them
+        // if we switch to using them as link to the first child (as before)
+        // we can just uncomment that line
+        // entries[parent].pathToFirstChild = current.childMarkdownRemark.fields.slug;
+      });
+      entries[id].isSelected = current.childMarkdownRemark.fields.slug === slug;
+    }
+  }
+  return updateHeights(entries, expanded);
+}
+
+export default class TableOfContents extends PureComponent {
+  constructor(props) {
+    super(props);
+    const {slug, chapters, firstItemIsExpanded} = props;
+    const expanded = firstItemIsExpanded ? {0: true} : {};
+    const tocState = getTocState({slug, chapters, expanded});
+
+    // tocState contains the state of the TOC with information such as
+    // what is the current height of an entry?
+    // is an entry selected or is any of its children selected?
+    // expanded records whether the user manually expanded or collapsed
+    // a section of the TOC.
+    // why keep them separated? tocState get regenerated for instance
+    // when the slug changes (which may mean that some sections get expanded/collapsed)
+    // we don't want to overwrite the manual actions of the user in that case.
+    // instead, we first apply the "organic" changes of the toc, then on top of that
+    // we add the results of the user's action
+
+    this.state = {
+      tocState,
+      expanded
+    };
+    this.toggleEntry = this.toggleEntry.bind(this);
   }
 
-  return (
-    <TocEntry $depth={depth} title={name} onClick={() => toggleEntry(id)}>
-      {hasChildren && <TocChevron $depth={depth} $isTocOpen={isTocOpen} />}
-      {!path || typeof path !== 'string' ? (
-        <TocHeader $depth={depth}>{name}</TocHeader>
-      ) : (
-        <TocLink $depth={depth} to={path} title={name} $active={active}>
-          {name}
-        </TocLink>
-      )}
-    </TocEntry>
-  );
-};
+  componentDidUpdate(prevProps) {
+    const {chapters, slug} = this.props;
+    if (slug !== prevProps.slug) {
+      const {expanded} = this.state;
+      const tocState = getTocState({chapters, slug, expanded});
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        tocState,
+        expanded
+      });
+    }
+  }
 
-const renderRoute = ({route, id, index, depth, tocState, toggleEntry}) => {
-  const children = route.chapters || route.entries || [];
-  const updatedId = id.concat(index);
+  toggleEntry(id) {
+    const {expanded, tocState} = this.state;
+    let updatedExpanded = {...expanded};
+    const entry = tocState[id];
 
-  // parts of the TOC with children
+    // if this entry has been manually expanded, then we manually collapse it.
+    // else - either this entry has never been manually expanded/collapsed,
+    // or it has been manually collapsed - we expand it.
+    updatedExpanded[id] = !isOpen(entry, expanded);
+    // then we need to update the heights.
+    const updatedTocState = updateHeights({...tocState}, updatedExpanded);
 
-  if (children.length) {
-    const name = route.title;
-    const routeInfo = tocState[updatedId];
+    this.setState({
+      tocState: updatedTocState,
+      expanded: updatedExpanded
+    });
+  }
+
+  render() {
+    const {chapters: tree} = this.props;
+    const {tocState} = this.state;
+
+    if (!tree) {
+      return null;
+    }
     return (
-      <div key={index}>
-        <SafeLink
-          depth={depth}
-          hasChildren
-          isTocOpen={routeInfo && routeInfo.height > 0}
-          id={updatedId}
-          name={name}
-          /* uncomment to have the entry act as link to its first child */
-          /* path={routeInfo && routeInfo.pathToFirstChild} */
-          toggleEntry={toggleEntry}
-        />
-        <TocSubpages $height={routeInfo && routeInfo.height}>
-          {children.map((childRoute, idx) => {
-            if (!childRoute.childMarkdownRemark) {
-              console.warn(
-                `Missing content for entry ${idx} in chapter ${route.title}`,
-                route
-              );
-            }
-
-            return renderRoute({
-              depth: depth + 1,
-              id: updatedId,
-              index: idx,
-              route: childRoute,
-              tocState,
-              toggleEntry
-            });
-          })}
-        </TocSubpages>
-      </div>
+      <ControlledToc
+        tree={tree}
+        tocState={tocState}
+        toggleEntry={this.toggleEntry}
+      />
     );
   }
-
-  // leaves
-
-  const remark = route.childMarkdownRemark;
-  // first syntax is toc for documentation, second is toc for examples
-  const name =
-    (remark && remark.frontmatter && remark.frontmatter.title) || route.title;
-  const target = (remark && remark.fields && remark.fields.slug) || route.path;
-  return (
-    <div key={index}>
-      <li>
-        <SafeLink
-          active={
-            tocState[updatedId] && tocState[updatedId].isSelected === true
-          }
-          depth={depth}
-          name={name}
-          path={target}
-        />
-      </li>
-    </div>
-  );
-};
-
-const ControlledToc = ({tree, tocState, toggleEntry}) => {
-  return (
-    <>
-      {tree.map((route, index) =>
-        renderRoute({
-          route,
-          index,
-          depth: 0,
-          tocState,
-          toggleEntry,
-          id: []
-        })
-      )}
-    </>
-  );
-};
+}

--- a/modules/gatsby/src/components/layout/top-level-layout.jsx
+++ b/modules/gatsby/src/components/layout/top-level-layout.jsx
@@ -11,29 +11,29 @@ import {WebsiteConfigProvider} from './website-config';
 import SEO from '../common/SEO';
 
 import TableOfContents from './table-of-contents';
-import Header from './header';
+import Header, {DocsHeader} from './header';
 
 import {
   BodyContainerFull,
   BodyContainerToC,
-  BodyGrid,
+  Body,
   HeaderContainer,
   TocContainer,
-  TocToggle,
+  TocToggle
 } from '../styled';
-
 
 // TODO/ib - restore footer
 // import Footer from './footer';
 
 function ResponsiveHeader(props) {
+  const HeaderComponent = props.isDocHeader ? DocsHeader : Header;
   return (
     <div>
       <MediaQuery maxWidth={575}>
-        <Header {...props} isSmallScreen />
+        <HeaderComponent {...props} isSmallScreen />
       </MediaQuery>
       <MediaQuery minWidth={576}>
-        <Header {...props} />
+        <HeaderComponent {...props} />
       </MediaQuery>
     </div>
   );
@@ -43,16 +43,22 @@ export default class Layout extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isMenuOpen: false,
+      isProjectsMenuOpen: false,
+      isLinksMenuOpen: false,
       isTocOpen: false
     };
-    this.toggleMenu = this.toggleMenu.bind(this);
+    this.toggleProjectsMenu = this.toggleProjectsMenu.bind(this);
+    this.toggleLinksMenu = this.toggleLinksMenu.bind(this);
     this.toggleToc = this.toggleToc.bind(this);
   }
 
-  toggleMenu() {
-    const {isMenuOpen} = this.state;
-    this.setState({isMenuOpen: !isMenuOpen});
+  toggleLinksMenu() {
+    const {isLinksMenuOpen} = this.state;
+    this.setState({isLinksMenuOpen: !isLinksMenuOpen});
+  }
+  toggleProjectsMenu() {
+    const {isProjectsMenuOpen} = this.state;
+    this.setState({isProjectsMenuOpen: !isProjectsMenuOpen});
   }
   toggleToc() {
     const {isTocOpen} = this.state;
@@ -66,27 +72,36 @@ export default class Layout extends React.Component {
 
   renderBodyWithTOC(config, tableOfContents) {
     const {children} = this.props;
-    const {isMenuOpen, isTocOpen} = this.state;
+    const {isLinksMenuOpen, isProjectsMenuOpen, isTocOpen} = this.state;
+    const isMenuOpen = isLinksMenuOpen || isProjectsMenuOpen;
     // first div is to avoid the BodyGrid div className to be overwritten
     return (
       <div>
-        <BodyGrid>
+        <Body>
           <HeaderContainer>
             <ResponsiveHeader
               config={config}
-              isMenuOpen={isMenuOpen}
-              toggleMenu={this.toggleMenu}
+              isLinksMenuOpen={isLinksMenuOpen}
+              isProjectsMenuOpen={isProjectsMenuOpen}
+              toggleLinksMenu={this.toggleLeftMenu}
+              toggleProjectsMenu={this.toggleProjectsMenu}
+              isDocHeader
             />
           </HeaderContainer>
-          <TocToggle toggleToc={this.toggleToc} isTocOpen={isTocOpen} />
-          <TocContainer $isTocOpen={isTocOpen}> 
+          <TocToggle
+            toggleToc={this.toggleToc}
+            isMenuOpen={isMenuOpen}
+            isTocOpen={isTocOpen}
+          />
+          <TocContainer $isTocOpen={isTocOpen}>
             {this.renderTOC(config, tableOfContents)}
           </TocContainer>
 
-          <BodyContainerToC $isTocOpen={isTocOpen}>{children}</BodyContainerToC>
-
+          <BodyContainerToC $isTocOpen={isTocOpen} $isMenuOpen={isMenuOpen}>
+            {children}
+          </BodyContainerToC>
           {/* <Footer /> */}
-        </BodyGrid>
+        </Body>
       </div>
     );
   }

--- a/modules/gatsby/src/components/layout/top-level-layout.jsx
+++ b/modules/gatsby/src/components/layout/top-level-layout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-did-update-set-state */
 // This is the top-level "Layout" component that doesn't get unmounted between
 // page loads. This component is wrapped around the react component returned by
 // each page by 'gatsby-plugin-layout'
@@ -11,7 +12,8 @@ import {WebsiteConfigProvider} from './website-config';
 import SEO from '../common/SEO';
 
 import TableOfContents from './table-of-contents';
-import Header, {DocsHeader} from './header';
+import Header from './header';
+import DocsHeader from './docs-header';
 
 import {
   BodyContainerFull,
@@ -52,22 +54,25 @@ export default class Layout extends React.Component {
     this.toggleToc = this.toggleToc.bind(this);
   }
 
-  toggleLinksMenu() {
-    const {isLinksMenuOpen} = this.state;
-    this.setState({isLinksMenuOpen: !isLinksMenuOpen});
-  }
-  toggleProjectsMenu() {
-    const {isProjectsMenuOpen} = this.state;
-    this.setState({isProjectsMenuOpen: !isProjectsMenuOpen});
-  }
-  toggleToc() {
-    const {isTocOpen} = this.state;
-    this.setState({isTocOpen: !isTocOpen});
-  }
   componentDidUpdate(prevProps) {
     if (prevProps.pageContext.slug !== this.props.pageContext.slug) {
       this.setState({isTocOpen: false});
     }
+  }
+
+  toggleLinksMenu() {
+    const {isLinksMenuOpen} = this.state;
+    this.setState({isLinksMenuOpen: !isLinksMenuOpen});
+  }
+
+  toggleProjectsMenu() {
+    const {isProjectsMenuOpen} = this.state;
+    this.setState({isProjectsMenuOpen: !isProjectsMenuOpen});
+  }
+  
+  toggleToc() {
+    const {isTocOpen} = this.state;
+    this.setState({isTocOpen: !isTocOpen});
   }
 
   renderBodyWithTOC(config, tableOfContents) {

--- a/modules/gatsby/src/components/styled/header.js
+++ b/modules/gatsby/src/components/styled/header.js
@@ -16,7 +16,7 @@ export const Header = styled('header', ({$theme}) => ({
   width: '100%',
   userSelect: 'none',
   [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
-    position: 'fixed',
+    position: 'fixed'
   },
   [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     position: 'static'
@@ -27,15 +27,15 @@ export const HeaderContainer = styled('div', ({$theme, ...props}) => ({
   gridColumn: '1 / 3',
   gridRow: '1 / 2',
   zIndex: 2,
-  [`@media screen and (max-width: ${$theme.breakpoints.medium})`]: {
+  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     order: 1
   }
 }));
 
 export const HeaderMenuBlock = styled('div', ({$theme, ...props}) => ({
-    alignItems: 'center',
-    display: 'flex',
-    flexDirection: 'row'
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'row'
 }));
 
 export const HeaderLogo = styled('a', ({$theme}) => ({
@@ -50,34 +50,57 @@ export const HeaderLogo = styled('a', ({$theme}) => ({
 }));
 
 export const HeaderMenu = styled('div', ({$theme, $collapsed, $nbItems}) => ({
+  background: $theme.colors.mono1000,
   display: 'flex',
   flexDirection: 'column',
-  position: 'fixed',
-  background: $theme.colors.mono1000,
-  minWidth: '180px',
-  maxHeight: $collapsed ? 0 : `${$nbItems * 48}px`,
-  top: '64px',
-  left: '16px',
-  overflow: 'hidden',
-  transition: 'max-height 0.3s'
+  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
+    height: `calc(100% - ${$theme.sizing.scale1600})`,
+    left: '-36px',
+    marginLeft: '36px',
+    padding: `${$theme.sizing.scale2400} ${$theme.sizing.scale800} ${$theme.sizing.scale1600} ${$theme.sizing.scale500}`,
+    position: 'fixed',
+    top: $theme.sizing.scale1600,
+    transform: $collapsed ? 'translate(-100%)' : 'translate(0)',
+    overflow: 'hidden',
+    transition: 'transform 0.3s',
+    width: '100%',
+    zIndex: 100,
+  },
+  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+    position: 'fixed',
+    minWidth: '180px',
+    maxHeight: $collapsed ? 0 : `${$nbItems * 48}px`,
+    top: $theme.sizing.scale1600,
+    left: $theme.sizing.scale600,
+    overflow: 'hidden',
+    transition: 'max-height 0.3s'
+  }
 }));
 
-export const HeaderMenuLink = styled('a', ({$theme}) => ({
+export const HeaderMenuLink = styled('a', ({$theme, ...props}) => {
+  return {
   display: 'block',
-  lineHeight: '48px',
-  padding: '0 16px',
+  padding: `0 ${$theme.sizing.scale1600}`,
   textDecoration: 'none',
+  [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
+    ...$theme.typography.font300,
+    lineHeight: $theme.sizing.scale1200,
+  },
+  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
+    fontSize: '36px',
+    lineHeight: $theme.sizing.scale1600
+  },
   ':visited': {color: $theme.colors.mono100},
   ':active': {color: $theme.colors.mono100},
   ':hover': {color: $theme.colors.mono100}
-}))
+}});
 
 export const HeaderLinksBlock = styled('div', ({$theme, ...props}) => ({
   display: 'flex',
   alignItems: 'center'
 }));
 
-const StyledHamburgerMenu  = styled('div', ({$theme}) => ({
+const StyledHamburgerMenu = styled('div', ({$theme}) => ({
   cursor: 'pointer',
   justifyContent: 'space-between',
   display: 'flex',
@@ -85,13 +108,13 @@ const StyledHamburgerMenu  = styled('div', ({$theme}) => ({
   padding: '3px 1px 4px',
   marginRight: $theme.sizing.scale600,
   height: $theme.sizing.scale800,
-  width: $theme.sizing.scale800,
+  width: $theme.sizing.scale800
 }));
 
 const HamburgerBar = styled('div', ({$theme}) => ({
   backgroundColor: $theme.colors.mono100,
   height: '3px',
-  width: '100%',
+  width: '100%'
 }));
 
 export const HamburgerMenu = ({onClick}) => (
@@ -100,7 +123,7 @@ export const HamburgerMenu = ({onClick}) => (
     <HamburgerBar />
     <HamburgerBar />
   </StyledHamburgerMenu>
-)
+);
 
 export const HeaderA = styled('a', ({$theme}) => ({
   color: $theme.colors.mono100,

--- a/modules/gatsby/src/components/styled/index.js
+++ b/modules/gatsby/src/components/styled/index.js
@@ -2,12 +2,31 @@
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import ChevronDown from 'baseui/icon/chevron-down'
+import ChevronDown from 'baseui/icon/chevron-down';
 import {styled} from 'baseui';
 
-// Typography 
+// Typography
 
-export {A, CodeBlock, H1, H2, H3, H4, H5, H6, List, ListItem, BlockQuote, Table, TableHeaderCell, TableBodyCell, InlineCode, MarkdownBody, P, Pre} from './typography';
+export {
+  A,
+  CodeBlock,
+  H1,
+  H2,
+  H3,
+  H4,
+  H5,
+  H6,
+  List,
+  ListItem,
+  BlockQuote,
+  Table,
+  TableHeaderCell,
+  TableBodyCell,
+  InlineCode,
+  MarkdownBody,
+  P,
+  Pre
+} from './typography';
 
 // Header
 
@@ -34,58 +53,55 @@ export {
   TocHeader,
   TocLink,
   TocSubpages,
-  TocToggle,
+  TocToggle
 } from './toc';
-
 
 // top-level layoout
 
 export const BodyContainerFull = styled('div', ({$theme, ...props}) => ({
-  margin: '0 auto',
+  margin: '0 auto'
 }));
-
 
 export const BodyContainerToC = styled(
   'div',
-  ({$theme, $isTocOpen, ...props}) => ({
+  ({$theme, $isMenuOpen, $isTocOpen, ...props}) => ({
     width: '100%',
-    padding: $theme.sizing.scale500,
     [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
-      gridColumn: '2 / 3',
-      gridRow: '2 / 3',
+      padding: `${$theme.sizing.scale500} ${$theme.sizing.scale500} ${
+        $theme.sizing.scale500
+      } 300px`,
+      marginTop: '64px', // height of header
+      transform: 'scaleY(1)',
+      opacity: 1
     },
     [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
+      padding: $theme.sizing.scale500,
+      marginTop: 0,
       order: 2,
-      transition: 'opacity 0.3s'
-    },
+      transition: 'opacity 0.3s',
+      ...($isTocOpen || $isMenuOpen
+        ? {
+            transform: 'scaleY(0)',
+            opacity: 0
+          }
+        : {
+            transform: 'scaleY(1)',
+            opacity: 1
+          })
+    }
     // the problem the following is solving is what happens if the document is very long
     // on a responsive device. If the user toggles the table of content, because the
     // document is long, the TOC will be not visible (above the viewport).
     // to address that, when the TOC is open, we are removing the document from the flow, so
     // that the TOC will be visible. Now, there are several ways to do that, some of which
     // introduce another problem - when closing the table of contents, we want the user to be
-    // back exactly where they were before they opened it, as opposed to back on the top. 
-    // that's one way to approach this - 
-    ...($isTocOpen ? {
-      transform: 'scaleY(0)',
-      opacity: 0,
-    } : {
-      transform: 'scaleY(1)',
-      opacity: 1,
-    })
+    // back exactly where they were before they opened it, as opposed to back on the top.
+    // that's one way to approach this -
   })
 );
 
-export const BodyGrid = styled('div', ({$theme, ...props}) => ({
-  height: '100vh',
-  display: 'grid',
-  gridTemplateRows: '64px 1fr',
-  gridTemplateColumns: '300px 1fr',
-  [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: 'inherit'
-  }
+export const Body = styled('div', ({$theme, ...props}) => ({
+  height: '100vh'
 }));
 
 // example

--- a/modules/gatsby/src/components/styled/toc.js
+++ b/modules/gatsby/src/components/styled/toc.js
@@ -67,12 +67,13 @@ export const TocSubpages = styled('ul', ({$height, ...props}) => ({
 
 export const TocContainer = styled('div', ({$theme, $isTocOpen, ...props}) => ({
   [`@media screen and (min-width: ${$theme.breakpoints.medium}px)`]: {
-    gridColumn: '1 / 2',
-    gridRow: '2 / 3',
+    position: 'fixed',
+    maxWidth: '300px',
+    height: '100%',
+    zIndex: 2,
     borderRight: `1px solid ${$theme.colors.mono500}`,
     overflowY: 'scroll',
     overflowX: 'hidden',
-    position: 'static'
   },
   [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
     // order: 3,
@@ -123,11 +124,13 @@ const TocToggleChevron = styled('div', ({$theme, $isTocOpen}) => ({
   width: $theme.sizing.scale600
 }));
 
-export const TocToggle = ({toggleToc, isTocOpen}) => (
-  <StyledTocToggle onClick={toggleToc}>
-    <TocToggleChevron $isTocOpen={isTocOpen}>
-      <ChevronDown />
-    </TocToggleChevron>
-    Table of Contents
-  </StyledTocToggle>
-);
+export const TocToggle = ({toggleToc, isTocOpen, isMenuOpen}) => {
+  return isMenuOpen ? null : (
+    <StyledTocToggle onClick={toggleToc}>
+      <TocToggleChevron $isTocOpen={isTocOpen}>
+        <ChevronDown />
+      </TocToggleChevron>
+      Table of Contents
+    </StyledTocToggle>
+  );
+};


### PR DESCRIPTION
The point of this PR is to ensure we have scroll conservation when we change routes. 
Currently, when a user clicks on a link in the TOC, in the new page both the TOC and main page scroll to top. 
To prevent that, instead of a layout using display: grid, we:
- have the TOC displayed using fixed and positioned right under the header. we also give a zindex so it can be displayed over the rest of the page;
- add padding to the main part of the screen. the left padding corresponds to the toc width. 
As a result, both parts scroll independently and scrolling position is conserved when changing pages. 

The behavior for smaller screens is conserved, ie: when = table of contents is clicked, the toc will replace the documentation. 

However, the small screens had an additional problem that this PR fixes, which is the behavior of the project links menu. Previously, this menu will appear under the "table of contents" toggle, and would stay on when scrolling down the page. (fixed position). 

Instead, I implement the design, which is: when we click on the hamburger menu, the list of projects takes over the main page. The implementation of that had to be slightly different for pages with TOC and pages without. 

![scroll conservation - full - small](https://user-images.githubusercontent.com/9727630/65088894-e77f7d00-d96f-11e9-96bc-d2fe4d5674ae.gif)
![scroll conservation - full - wide](https://user-images.githubusercontent.com/9727630/65088895-e8181380-d96f-11e9-81a8-4f9d5377811c.gif)
