### PR TITLE
tweak build to accept options to build selected targets.

### DIFF
--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -7,7 +7,7 @@ CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 
 check_target() {
   if [[ ! $1 =~ ^es5|es6|esm ]]; then
-    echo "Build target $1 not recognized."
+    echo -e "\033[91mUnknown build target $1. ocular-build [-t es5|es6|esm,...] [module1,...]\033[0m"
     exit 1
   fi
 }
@@ -44,7 +44,7 @@ build_monorepo() {
             TARGET=$2
             shift ;;
         *)
-            echo "Option $1 not recognized."
+            echo -e "\033[91mUnknown option $1. ocular-build [-t es5|es6|esm,...] [module1,...]\033[0m"
             exit 1 ;;
       esac
     else

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -58,7 +58,7 @@ build_monorepo() {
 
   cd modules
 
-  if [ -z "$MODULES"]; then
+  if [ -z "$MODULES" ]; then
     # Build all modules
     MODULES=`ls`
   fi

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -5,10 +5,29 @@ set -e
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 
+check_target() {
+  if [[ ! $1 =~ ^es5|es6|esm ]]; then
+    echo "Build target $T not recognized."
+    exit 1
+  fi
+}
+
 build_module() {
-  BABEL_ENV=es6 npx babel src --config-file $CONFIG --out-dir dist/es6 --source-maps
-  BABEL_ENV=esm npx babel src --config-file $CONFIG --out-dir dist/esm --source-maps
-  BABEL_ENV=es5 npx babel src --config-file $CONFIG --out-dir dist/es5 --source-maps
+  if [ -z "$1" ]; then
+    TARGETS="es6 esm es5"
+  else
+    TARGETS=$*
+  fi
+  N=`echo "$TARGETS" | wc -w`
+  if [ $N -eq 1 ]; then
+    check_target $TARGETS
+    BABEL_ENV=$TARGETS npx babel src --config-file $CONFIG --out-dir dist --source-maps
+  else
+    for T in ${TARGETS}; do(
+      check_target $T
+      BABEL_ENV=$T npx babel src --config-file $CONFIG --out-dir dist/$T --source-maps
+    ); done
+  fi
 }
 
 build_unirepo() {
@@ -16,29 +35,46 @@ build_unirepo() {
 }
 
 build_monorepo() {
+  MODULES=""
+
+  while [ -n "$1" ]; do
+    if [[ $1 =~ ^\-[A-Za-z] ]]; then
+      case "$1" in
+        -t)
+            TARGET=$2
+            shift
+            break ;;
+        *)
+            echo "Option $1 not recognized."
+            exit 1 ;;
+      esac
+    else
+      # Build selected modules
+      # build.sh MODULE1,MODULE2
+      MODULES=`echo $1 | sed -e 's/,/ /g'`
+    fi
+    shift
+  done
+
   cd modules
 
-  if [ -z "$1" ]; then
+  if [ -z "$MODULES"]; then
     # Build all modules
     MODULES=`ls`
-  else
-    # Build selected modules
-    # build.sh MODULE1,MODULE2
-    MODULES=`echo $1 | sed -e 's/,/ /g'`
   fi
 
   for D in ${MODULES}; do (
     if [ -e "${D}/package.json" ]; then
       echo -e "\033[1mBuilding modules/$D\033[0m"
       cd $D
-      build_module
+      build_module `echo $TARGET | sed -e 's/,/ /g'`
       echo ""
     fi
   ); done
 }
 
 if [ -d "modules" ]; then
-  build_monorepo $1
+  build_monorepo $*
 else
   build_unirepo
 fi

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -42,8 +42,7 @@ build_monorepo() {
       case "$1" in
         -t)
             TARGET=$2
-            shift
-            break ;;
+            shift ;;
         *)
             echo "Option $1 not recognized."
             exit 1 ;;

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -7,7 +7,7 @@ CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 
 check_target() {
   if [[ ! $1 =~ ^es5|es6|esm ]]; then
-    echo "Build target $T not recognized."
+    echo "Build target $1 not recognized."
     exit 1
   fi
 }

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -6,8 +6,8 @@ DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 
 check_target() {
-  if [[ ! $1 =~ ^es5|es6|esm ]]; then
-    echo -e "\033[91mUnknown build target $1. ocular-build [-t es5|es6|esm,...] [module1,...]\033[0m"
+  if [[ ! "$1" =~ ^es5|es6|esm ]]; then
+    echo -e "\033[91mUnknown build target $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"
     exit 1
   fi
 }
@@ -38,13 +38,13 @@ build_monorepo() {
   MODULES=""
 
   while [ -n "$1" ]; do
-    if [[ $1 =~ ^\-[A-Za-z] ]]; then
+    if [[ "$1" =~ ^\-\-[A-Za-z]+ ]]; then
       case "$1" in
-        -t)
+        --dist)
             TARGET=$2
             shift ;;
         *)
-            echo -e "\033[91mUnknown option $1. ocular-build [-t es5|es6|esm,...] [module1,...]\033[0m"
+            echo -e "\033[91mUnknown option $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"
             exit 1 ;;
       esac
     else

--- a/modules/dev-tools/scripts/clean.sh
+++ b/modules/dev-tools/scripts/clean.sh
@@ -3,7 +3,14 @@
 set -e
 
 clean() {
-  rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6
+  if [ -z "$1" ]; then
+    rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6
+  elif [ "$1" = "-a" ]; then
+    rm -fr dist
+  else
+    echo "Option $1 not recognized."
+    exit 1
+  fi
 }
 
 if [ -d "modules" ]; then
@@ -12,8 +19,8 @@ if [ -d "modules" ]; then
 
   for D in *; do (
     cd $D
-    clean
+    clean $1
   ); done
 else
-  clean
+  clean $1
 fi

--- a/modules/dev-tools/scripts/clean.sh
+++ b/modules/dev-tools/scripts/clean.sh
@@ -8,7 +8,7 @@ clean() {
   elif [ "$1" = "-a" ]; then
     rm -fr dist
   else
-    echo "Option $1 not recognized."
+    echo -e "\033[91mUnknown option $1. ocular-clean [-a]\033[0m"
     exit 1
   fi
 }

--- a/modules/dev-tools/scripts/clean.sh
+++ b/modules/dev-tools/scripts/clean.sh
@@ -5,10 +5,10 @@ set -e
 clean() {
   if [ -z "$1" ]; then
     rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6
-  elif [ "$1" = "-a" ]; then
+  elif [ "$1" = "all" ]; then
     rm -fr dist
   else
-    echo -e "\033[91mUnknown option $1. ocular-clean [-a]\033[0m"
+    echo -e "\033[91mUnknown option $1. ocular-clean [all]\033[0m"
     exit 1
   fi
 }


### PR DESCRIPTION
tweak ocular-build to accept options to build selected targets. Addressing this issue https://github.com/uber/manifold/issues/31.

**ocular-build**

Usage:

```
ocular-build [--dist es5|es6|esm,...] [module,...]
```

Example:

```
ocular-build --dist es6,esm
ocular-build --dist esm
ocular-build --dist es6,esm module1
ocular-build module1
```

New Behaviors:
1. If there's only one option after `--dist`, then the bundle will be built into `dist/` (without `esm/` etc .)
2. If there are unrecognized parameter after the `--dist` option, ocular will give an error message and exit.
3. The pattern with `\-\-[a-zA-Z]+` after `ocular-build` is now reserved for options, in the other words, there can't be a module named as these, e.g. `--m` as module...

**ocular-clean**

Usage

```
ocular-clean [all]
```

New Behavior:
1. If the `all' option is used, clean the entire dist/ without making empty es5/ es6/ esm/