### PR TITLE
ie11 fixes

### DIFF
--- a/modules/gatsby/gatsby-browser.js
+++ b/modules/gatsby/gatsby-browser.js
@@ -1,3 +1,6 @@
+// ie 11 polyfill
+import 'whatwg-fetch';
+
 export {default as wrapPageElement} from './src/gatsby-common/wrap-page';
 
 export function onClientEntry() {

--- a/modules/gatsby/package.json
+++ b/modules/gatsby/package.json
@@ -2,7 +2,7 @@
   "name": "ocular-gatsby",
   "description": "GatsbyJS plugin for rendering markdown docs for frameworks.",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/modules/gatsby/src/components/github/github-contributors.jsx
+++ b/modules/gatsby/src/components/github/github-contributors.jsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import styled from 'styled-components';
-// ie 11 polyfill
-import 'whatwg-fetch';
+
 
 
 // Github api has rate-limits. We want to cache the response

--- a/modules/gatsby/src/components/github/github-stars.jsx
+++ b/modules/gatsby/src/components/github/github-stars.jsx
@@ -1,7 +1,5 @@
 import React, {Component, Fragment} from 'react';
 import StarIcon from 'react-icons/lib/go/star';
-// ie 11 polyfill
-import 'whatwg-fetch';
 
 // Github api has rate-limits. We want to cache the response
 // as much as we can. This component gets re-mounted multiple times.

--- a/modules/gatsby/website-template/package.json
+++ b/modules/gatsby/website-template/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gatsby": "^2.3.0",
-    "ocular-gatsby": "^1.0.1",
+    "ocular-gatsby": "^1.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },


### PR DESCRIPTION
well, turns out we shouldn't import that polyfill in the component. instead, we should import it in the gatsby-browser file. i had published the previous version as 1.0.2, looks like i'll have to publish 1.0.3