### PR TITLE
Processing an optional modules field in ocular-dev-tools.config.js, currently only applicable to ocular-build

### DIFF
--- a/modules/dev-tools/node/get-config.js
+++ b/modules/dev-tools/node/get-config.js
@@ -9,6 +9,6 @@ configPath.split('.')
   });
 
 if (typeof config !== 'string') {
-  config = JSON.stringify(config);
+  config = config === undefined ? "" : JSON.stringify(config);
 }
 console.log(config);

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -4,7 +4,7 @@ set -e
 
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
-WORKSPACES=`node $DEV_TOOLS_DIR/node/get-config.js ".workspaces" | jq -r 'join(" ")'`
+MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".workspaces" | jq -r 'join(" ")'`
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then
@@ -36,8 +36,6 @@ build_unirepo() {
 }
 
 build_monorepo() {
-  MODULES=""
-
   while [ -n "$1" ]; do
     if [[ "$1" =~ ^\-\-[A-Za-z]+ ]]; then
       case "$1" in
@@ -56,12 +54,9 @@ build_monorepo() {
     shift
   done
 
-  if [ -z "$MODULES" ] && [ -z "$WORKSPACES" ]; then
+  if [ -z "$MODULES" ]; then
     # Build all modules
     MODULES=`find modules -mindepth 1 -maxdepth 1 -not \( -name ".*" \)`
-  elif [ -z "$MODULES" ]; then
-    # Build the worksplaces
-    MODULES=$WORKSPACES
   fi
 
   for D in ${MODULES}; do (

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -4,7 +4,7 @@ set -e
 
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
-MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".workspaces" | jq -r 'join(" ")'`
+MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".modules" | jq -r 'join(" ")'`
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -66,9 +66,13 @@ build_monorepo() {
 
   for D in ${MODULES}; do (
     if [ -e "${D}/package.json" ]; then
-      echo -e "\033[1mBuilding modules/$D\033[0m"
+      echo -e "\033[1mBuilding $D\033[0m"
       cd $D
       build_module `echo $TARGET | sed -e 's/,/ /g'`
+      echo ""
+    elif [ ! -e "${D}" ]; then
+      echo -e "\033[1mWarning: skipping $D because it doesn't match any file.\033[0m"
+      echo -e "\033[1mHint: modules must be specified using full path relative to the project root.\033[0m"
       echo ""
     fi
   ); done

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -56,9 +56,12 @@ build_monorepo() {
     shift
   done
 
-  if [ -z "$MODULES" ]; then
+  if [ -z "$MODULES" ] && [ -z "$WORKSPACES" ]; then
     # Build all modules
     MODULES=`find modules -mindepth 1 -maxdepth 1 -not \( -name ".*" \)`
+  elif [ -z "$MODULES" ]; then
+    # Build the worksplaces
+    MODULES=$WORKSPACES
   fi
 
   for D in ${MODULES}; do (

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -4,6 +4,7 @@ set -e
 
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
+WORKSPACES=`node $DEV_TOOLS_DIR/node/get-config.js ".workspaces" | jq -r 'join(" ")'`
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then
@@ -55,11 +56,9 @@ build_monorepo() {
     shift
   done
 
-  cd modules
-
   if [ -z "$MODULES" ]; then
     # Build all modules
-    MODULES=`ls`
+    MODULES=`find modules -mindepth 1 -maxdepth 1 -not \( -name ".*" \)`
   fi
 
   for D in ${MODULES}; do (


### PR DESCRIPTION
Addresses the issue in https://github.com/uber/manifold/issues/32

An optional field `modules` is now processed if added into `ocular-dev-tools.config.js`, similar to the `packages` field in `lerna.json`. Currently, this option is only applicable to `ocular-build`.

**Example Usage**:

in `ocular-dev-tools.config.js`
```javascript
module.exports = {
 ...
 modules: ['modules/*', 'bindings/pydeck-modules/*']
};
```

**New Behaviors**:
1) if the `modules` field is empty, no new behavior is added.
2) if the `modules` field is provided, it will override the default modules folder for `ocular-build`, which is `modules`.
3) if there are module list provided as the parameter for `ocular-build`, e.g. `ocular-build module1,module2`, then this list will override the `modules` setting during `ocular-build`.
4) `ocular-build` now has a new dependency on `jq`, which is not out-of-box in bash (the user has to install `jq`). But this dependency is already prevalent in other ocular commands.

**Breaking Change**:
1) The module list parameter for `ocular-build` now has to be the full relative path to the repo, e.g. `ocular-build core,json,react` will have to changed to `ocular-build modules/core,modules/json,modules/react`.

**FAQ**:
1) Q: Are there plans to make the `modules` settings work with other commands such as `ocular-publish`.
    A: Yes
2) Q: Why not simply use the `packages` setting in lerna.json.
     A: Ocular is supposed to be a standalone tool independent of `lerna`, although it may use some lerna features (it currently depends on lerna), but those features should be exposed as ocular features to the end-user. Ocular should not require a `lerna.json` file to work. Thus, ocular needs to have its own `modules` settings.  
