### PR TITLE
better treatment of readme.md files

### DIFF
--- a/modules/gatsby/src/gatsby-node/process-nodes/process-nodes-markdown.js
+++ b/modules/gatsby/src/gatsby-node/process-nodes/process-nodes-markdown.js
@@ -29,7 +29,7 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
   tocNode
 ) {
   const {createNodeField} = actions;
-
+debugger;
   const fileNode = getNode(node.parent);
   const parsedFilePath = path.parse(fileNode.relativePath);
   const hasTitle =
@@ -49,6 +49,7 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
 
   // Update path
   let relPath = node.fields.slug;
+  let entry = relPath;
   if (node.fileAbsolutePath) {
 
     const {ocularConfig} = global;
@@ -69,7 +70,8 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
 
     const basename = path.basename(relPath, '.md');
     const dirname = path.dirname(relPath);
-    relPath = basename === 'README' ? dirname : `${dirname}/${basename}`;
+    entry = `${dirname}/${basename}`;
+    relPath = basename === 'README' ? dirname : entry;
 
     createNodeField({node, name: 'path', value: relPath});
     createNodeField({node, name: 'slug', value: relPath});
@@ -84,7 +86,7 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
     // we don't need as much. The app will only use the title and slug of the corresponding markdown
     // node for each toc entry.
 
-    const nodeToEdit = parseToc([tocNode], relPath);
+    const nodeToEdit = parseToc([tocNode], entry);
     if (nodeToEdit) {
       nodeToEdit.childMarkdownRemark = {
         fields: {

--- a/modules/gatsby/src/gatsby-node/process-nodes/process-nodes-markdown.js
+++ b/modules/gatsby/src/gatsby-node/process-nodes/process-nodes-markdown.js
@@ -29,7 +29,6 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
   tocNode
 ) {
   const {createNodeField} = actions;
-debugger;
   const fileNode = getNode(node.parent);
   const parsedFilePath = path.parse(fileNode.relativePath);
   const hasTitle =


### PR DESCRIPTION
This is related to https://github.com/uber-web/ocular/issues/268. 
If the TOC was parsed before markdown files, we try to find the corresponding entry to a markdown file in the TOC as we go. We were doing that by matching the relPath variable to the entry property of a toc node. These values typically match but for a readme.md node the syntax of the relPath is going to be slightly different. This PR solves this problem. 