### PR TITLE
dev-tools: ocular-build - babel now called with --copy-files

### DIFF
--- a/modules/dev-tools/CHANGELOG.md
+++ b/modules/dev-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG (ocular-dev-tools)
 
+## v0.0.32
+- ocular-build: babel now called with --copy-files (#276)
+
+## v0.0.31
+- Update bump script to use full package name (#265)
+
 ## v0.0.30
 - test assertions (#248)
 - tweak build to accept options to build selected targets. (#251)

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -2,7 +2,7 @@
   "name": "ocular-dev-tools",
   "description": "Dev tools for our Javascript frameworks",
   "license": "MIT",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "keywords": [
     "javascript"
   ],

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -22,11 +22,11 @@ build_module() {
   N=`echo "$TARGETS" | wc -w`
   if [ $N -eq 1 ]; then
     check_target $TARGETS
-    BABEL_ENV=$TARGETS npx babel src --config-file $CONFIG --out-dir dist --source-maps
+    BABEL_ENV=$TARGETS npx babel src --config-file $CONFIG --out-dir dist --copy-files --source-maps
   else
     for T in ${TARGETS}; do(
       check_target $T
-      BABEL_ENV=$T npx babel src --config-file $CONFIG --out-dir dist/$T --source-maps
+      BABEL_ENV=$T npx babel src --config-file $CONFIG --out-dir dist/$T --copy-files --source-maps
     ); done
   fi
 }


### PR DESCRIPTION
Required for the loaders.gl 2x build speed fix.
