### PR TITLE
ocular-dev-tools@0.1.5

### DIFF
--- a/modules/dev-tools/CHANGELOG.md
+++ b/modules/dev-tools/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG (ocular-dev-tools)
 
+## v0.1.5
+- Fix bump script to detect peerDependencies (#284)
+
 ## v0.1.4
 - Fix building selected modules (#282)
 

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -2,7 +2,7 @@
   "name": "ocular-dev-tools",
   "description": "Dev tools for our Javascript frameworks",
   "license": "MIT",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "keywords": [
     "javascript"
   ],


### PR DESCRIPTION
published v0.1.5, but forgot to update the changelog and package.json