### PR TITLE
Gatsby - Add header logo link

### DIFF
--- a/docs/gatsby-theme-ocular/api-reference/options.md
+++ b/docs/gatsby-theme-ocular/api-reference/options.md
@@ -69,7 +69,7 @@ Each link entry has the following fields:
 | Field     | Type     | Name  |
 | ---       | ---      | ---   |
 | `name`    | `String` | Required. The displayed text in the header link. |
-| `href`    | `String` | Optional. The hyperlink you want to redirect to. This can be internal or external link. |
+| `href`    | `String` | Required. The hyperlink you want to redirect to. This can be internal or external link. |
 | `classnames` | `String` | Optional. The classname of the header link.
 | `index`      | `Int`    | Optional. Use 0 to push before first item. |
 

--- a/docs/gatsby-theme-ocular/api-reference/options.md
+++ b/docs/gatsby-theme-ocular/api-reference/options.md
@@ -24,6 +24,7 @@ The following options are available:
 | `PATH_PREFIX`        | `String` | Subdirectory in which the site will be hosted, e.g. `'/site'`. Note that `gatsby` must be run with the `--prefix-paths` option for this to work.|
 | `HOME_PATH`        | `String` | |
 | `PAGES`     | `Array`  | See below |
+| `HEADER_LINK_URL`        | `String` | Link that will be added on the anchor used for the header logo. It defaults to `/` if it's not defined.|
 | `ADDITIONAL_LINKS` | `Array` | See below |
 | `GA_TRACKING_ID`      | `String` | Google analytics tracking ID |
 | `GITHUB_KEY`       | `String` | The GitHub key for showing star counts and contributors. The value should be like `btoa('YourUsername:YourKey')` and the key should have readonly access. | |
@@ -68,8 +69,7 @@ Each link entry has the following fields:
 | Field     | Type     | Name  |
 | ---       | ---      | ---   |
 | `name`    | `String` | Required. The displayed text in the header link. |
-| `href`    | `String` | Optional. The hyperlink you want to redirect to. |
-| `to`   | `String` | Optional. The path to an internal gatsby page. Each entry will either only has `href` or `to`. |
+| `href`    | `String` | Optional. The hyperlink you want to redirect to. This can be internal or external link. |
 | `classnames` | `String` | Optional. The classname of the header link.
 | `index`      | `Int`    | Optional. Use 0 to push before first item. |
 

--- a/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
@@ -96,6 +96,13 @@
     "objectValidate": true
   },
 
+  "HEADER_LINK_URL": {
+    "anyString": {
+      "allowEmpty": true,
+      "message": "should be the path to the url used on the header logo'"
+    }
+  },
+
   "LINK_TO_GET_STARTED": {
     "anyString": {
       "allowEmpty": true,

--- a/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
@@ -12,6 +12,7 @@ const defaults = {
   SOURCE: 'website/src',
   EXAMPLES: [],
   DOCS: {},
+  HEADER_LINK_URL: '/',
   LINK_TO_GET_STARTED: '/docs',
   PROJECT_TYPE: '',
   PROJECT_NAME: 'Ocular',

--- a/modules/gatsby-theme-ocular/src/gatsby-node/source-nodes.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/source-nodes.js
@@ -54,6 +54,8 @@ function sourceNodes({actions}) {
       PROJECT_URL: String
       WEBSITE_PATH: String
 
+      HEADER_LINK_URL: String
+
       PROJECT_ORG_LOGO: String
 
       PAGES: [PageDesc]

--- a/modules/gatsby-theme-ocular/src/react/components/header.component.jsx
+++ b/modules/gatsby-theme-ocular/src/react/components/header.component.jsx
@@ -23,13 +23,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GithubIcon from 'react-icons/lib/go/mark-github';
 
+import {isInternalURL} from '../../utils/links-utils.js';
 import {
   HamburgerMenu,
   Header as StyledHeader,
-  HeaderLink as StyledLink,
+  HeaderLink,
+  HeaderLinkExternal,
+  HeaderLogo,
+  HeaderLogoExternal,
   HeaderLinksBlock,
   HeaderLinkContainer,
-  HeaderLogo,
   HeaderMenuBlock,
   HeaderMenu,
   HeaderMenuLink,
@@ -52,8 +55,24 @@ function GithubLink() {
   );
 }
 
-function HeaderLink({to, href, label}) {
-  return <StyledLink to={to || href}>{label}</StyledLink>;
+function UniversalHeaderLink({to, href, label}) {
+  const isInternal = href ? isInternalURL(href) : isInternalURL(to);
+
+  if (isInternal) {
+    return (<HeaderLink to={to || href}>{label}</HeaderLink>);
+  } else {
+    return (<HeaderLinkExternal href={to || href} target="_blank">{label}</HeaderLinkExternal>);
+  }
+}
+
+function UniversalLogoLink({to, label}) {
+  const isInternal = isInternalURL(to);
+
+  if (isInternal) {
+    return (<HeaderLogo to={to}>{label}</HeaderLogo>);
+  } else {
+    return (<HeaderLogoExternal href={to} target="_blank">{label}</HeaderLogoExternal>);
+  }
 }
 
 /**
@@ -101,7 +120,7 @@ const HeaderLinks = ({links}) => {
       {/* If the no examples marker, return without creating pages */}
       {links.map((link, index) => (
         <HeaderLinkContainer key={`link-${index}`}>
-          <HeaderLink {...link} />
+          <UniversalHeaderLink {...link} />
         </HeaderLinkContainer>
       ))}
       {/* this.renderStars() */}
@@ -118,7 +137,7 @@ const ControlledHeader = ({
   isMenuOpen,
   isSmallScreen
 }) => {
-  const {PROJECT_NAME, PROJECTS = []} = config;
+  const {PROJECT_NAME, PROJECTS = [], HEADER_LINK_URL = '/'} = config;
 
   const externalLinks = PROJECTS.map(({name, url}) => (
     <HeaderMenuLink key={`menulink-${name}`} href={url}>
@@ -134,7 +153,7 @@ const ControlledHeader = ({
   return isSmallScreen ? (
     <StyledHeader onClick={() => toggleMenu(false)} >
       <HeaderMenuBlock>
-        <HeaderLogo to="/">{PROJECT_NAME}</HeaderLogo>
+        <UniversalLogoLink to={HEADER_LINK_URL} label={PROJECT_NAME} />
         <HeaderMenu $collapsed={!isMenuOpen} $nbItems={links.length + 1}>
           <HeaderLinks links={links} />
         </HeaderMenu>
@@ -153,7 +172,7 @@ const ControlledHeader = ({
     <StyledHeader onClick={() => toggleMenu(false)} >
       <HeaderMenuBlock>
         <HamburgerMenu onClick={onClickHamburger} />
-        <HeaderLogo to="/">{PROJECT_NAME}</HeaderLogo>
+        <UniversalLogoLink to={HEADER_LINK_URL} label={PROJECT_NAME} />
         <HeaderMenu $collapsed={!isMenuOpen} $nbItems={PROJECTS.length}>
           {externalLinks}
         </HeaderMenu>

--- a/modules/gatsby-theme-ocular/src/react/site-query.jsx
+++ b/modules/gatsby-theme-ocular/src/react/site-query.jsx
@@ -22,6 +22,7 @@ const QUERY = graphql`
         PROJECT_ORG
         PROJECT_IMAGE
         PROJECT_ORG_LOGO
+        HEADER_LINK_URL
         LINK_TO_GET_STARTED
         PATH_PREFIX
         GA_TRACKING_ID

--- a/modules/gatsby-theme-ocular/src/react/styled/header.js
+++ b/modules/gatsby-theme-ocular/src/react/styled/header.js
@@ -52,6 +52,20 @@ export const HeaderLogo = styled(Link)`
   }
 `;
 
+export const HeaderLogoExternal = styled.a`
+  font: ${props => props.theme.typography.font450};
+  text-decoration: none;
+  &:visited {
+    color: ${props => props.theme.colors.mono100};
+  }
+  &:active {
+    color: ${props => props.theme.colors.mono200};
+  }
+  &:hover {
+    color: ${props => props.theme.colors.mono200};
+  }
+`;
+
 export const HeaderMenu = styled.div`
   background: ${props => props.theme.colors.mono1000};
   display: flex;
@@ -145,6 +159,20 @@ export const HamburgerMenu = ({onClick}) => (
 );
 
 export const HeaderLink = styled(Link)`
+  color: ${props => props.theme.colors.mono100};
+  text-decoration: none;
+  &:visited {
+    color: ${props => props.theme.colors.mono100};
+  }
+  &:active {
+    color: ${props => props.theme.colors.mono200};
+  }
+  &:hover {
+    color: ${props => props.theme.colors.mono200};
+  }
+`;
+
+export const HeaderLinkExternal = styled.a`
   color: ${props => props.theme.colors.mono100};
   text-decoration: none;
   &:visited {

--- a/modules/gatsby-theme-ocular/src/utils/links-utils.js
+++ b/modules/gatsby-theme-ocular/src/utils/links-utils.js
@@ -76,5 +76,15 @@ function addToRelativeLinks({source, target, rootFolder, edge, relativeLinks}) {
   };
 }
 
+function isInternalURL(to) {
+  try {
+    const url = new URL(to, window.location.origin);
+    return url.hostname === window.location.hostname;
+  } catch {
+    return false;
+  }
+}
+
 module.exports.addToRelativeLinks = addToRelativeLinks;
 module.exports.parseLinks = parseLinks;
+module.exports.isInternalURL = isInternalURL;

--- a/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
+++ b/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
@@ -11,6 +11,7 @@ const GOOD_CONFIG = {
   DIR_NAME: '/',
   EXAMPLES: [],
   DOCS: {},
+  HEADER_LINK_URL: '/',
   LINK_TO_GET_STARTED: '',
   PROJECT_TYPE: '',
   PROJECT_NAME: 'ocular',


### PR DESCRIPTION
Added the `HEADER_LINK_URL` field in the configuration that allows us to define the url that will be opened once the user clicks on the logo. By default it will take the user on the homepage (as before).

Also changed how links in the header work as Gatsby creates warnings if `Link` component is used for external links.
This also breaks the SPA experience if it isn't added properly.

One thing I had to expand is the GraphQL query in `ocular/modules/gatsby-theme-ocular/src/react/site-query.jsx`
If I don't add a new field there (`HEADER_LINK_URL`) this value won't be passed in the config that is available in the React components.

One thing that is confusing is the warning in the comment there that says:
`WARNING: DO NOT MODIFY THIS FILE MANUALLY IT WILL BE OVERWRITTEN.`

I can't see how this can be overwritten, or how to expand the available config unless I add this here.
So any help or clarification here is appreciated. 

@ibgreen @Pessimistress please review :) 