### PR TITLE
Gatsby - Set home path to docs directory

### DIFF
--- a/docs/gatsby-theme-ocular/api-reference/options.md
+++ b/docs/gatsby-theme-ocular/api-reference/options.md
@@ -22,7 +22,7 @@ The following options are available:
 | `PROJECT_IMAGE`    | `String` | Featured image of the project |
 | `PROJECTS`         | `Array`  | Array of links to related projects (header) |
 | `PATH_PREFIX`        | `String` | Subdirectory in which the site will be hosted, e.g. `'/site'`. Note that `gatsby` must be run with the `--prefix-paths` option for this to work.|
-| `HOME_PATH`        | `String` | Path to be removed in the relative path. If it equals `'docs'`, docs page will be the home page. If present, no other home page is generated. It defaults to `''` (empty string). |
+| `HOME_PATH`        | `String` | Path to be removed in the relative path. As an example, if it equals `'docs'`, docs page will be the home page. If present, no other home page is generated. Defaults to `''` (empty string). |
 | `PAGES`     | `Array`  | See below |
 | `HEADER_LINK_URL`        | `String` | Link that will be added on the anchor used for the header logo. It defaults to `/` if it's not defined.|
 | `ADDITIONAL_LINKS` | `Array` | See below |

--- a/docs/gatsby-theme-ocular/api-reference/options.md
+++ b/docs/gatsby-theme-ocular/api-reference/options.md
@@ -22,7 +22,7 @@ The following options are available:
 | `PROJECT_IMAGE`    | `String` | Featured image of the project |
 | `PROJECTS`         | `Array`  | Array of links to related projects (header) |
 | `PATH_PREFIX`        | `String` | Subdirectory in which the site will be hosted, e.g. `'/site'`. Note that `gatsby` must be run with the `--prefix-paths` option for this to work.|
-| `HOME_PATH`        | `String` | |
+| `HOME_PATH`        | `String` | Path to be removed in the relative path. If it equals `'docs'`, docs page will be the home page. If present, no other home page is generated. It defaults to `''` (empty string). |
 | `PAGES`     | `Array`  | See below |
 | `HEADER_LINK_URL`        | `String` | Link that will be added on the anchor used for the header logo. It defaults to `/` if it's not defined.|
 | `ADDITIONAL_LINKS` | `Array` | See below |

--- a/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
@@ -106,7 +106,7 @@
   "LINK_TO_GET_STARTED": {
     "anyString": {
       "allowEmpty": true,
-      "message": "should be the path to the 'Get Started' doc, or default to '/docs'"
+      "message": "should be the path to the 'Get Started' doc. Defaults to '/docs/'"
     }
   },
 

--- a/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/config-schema.json
@@ -106,7 +106,7 @@
   "LINK_TO_GET_STARTED": {
     "anyString": {
       "allowEmpty": true,
-      "message": "should be the path to the 'Get Started' doc, or default to '/docs/developer-guide/get-started'"
+      "message": "should be the path to the 'Get Started' doc, or default to '/docs'"
     }
   },
 

--- a/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
@@ -24,7 +24,7 @@ const defaults = {
   PROJECT_IMAGE: '',
   PROJECT_ORG_LOGO: '',
   PROJECTS: [],
-  HOME_PATH: '/',
+  HOME_PATH: '',
   THEME_OVERRIDES: '',
   STYLESHEETS: [],
   ADDITIONAL_LINKS: [],

--- a/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-doc-pages.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-doc-pages.js
@@ -63,7 +63,8 @@ function createDocMarkdownPages({graphql, actions}, ocularOptions) {
           target,
           rootFolder,
           edge,
-          relativeLinks
+          relativeLinks,
+          ocularOptions
         });
       });
 

--- a/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-pages.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-pages.js
@@ -19,7 +19,7 @@ module.exports = function createPages({graphql, actions}, ocularOptions) {
     searchPage = true // TODO - autodetect based on DEMOS config
   } = ocularOptions;
 
-  // don't create the index page if the Docs page is set to be index
+  // don't create the index page if HOME_PATH value is defined
   if (!ocularOptions.HOME_PATH) {
     createIndexPage({graphql, actions}, ocularOptions);
   }

--- a/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-pages.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-pages.js
@@ -19,7 +19,10 @@ module.exports = function createPages({graphql, actions}, ocularOptions) {
     searchPage = true // TODO - autodetect based on DEMOS config
   } = ocularOptions;
 
-  createIndexPage({graphql, actions}, ocularOptions);
+  // don't create the index page if the Docs page is set to be index
+  if (!ocularOptions.HOME_PATH) {
+    createIndexPage({graphql, actions}, ocularOptions);
+  }
 
   let docPromise;
   if (docPages) {

--- a/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-json.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-json.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const {log, COLOR} = require('../../utils/log');
-const {removeURLPath} = require('../../utils/links-utils');
+const {removeURLPathPrefix} = require('../../utils/links-utils');
 /* eslint-disable no-param-reassign */
 let tableOfContents = null;
 
@@ -17,9 +17,9 @@ function processEntry(chapter, entry, docNodes, ocularOptions) {
     return;
   }
   let relPath = entry.entry.replace(/^\//, '').replace(/\.[^/.]+$/, '').replace(/\/$/, '').replace('/README', '');
-  // remove part of the path to move root docs dir to index
+  // remove prefix from the path to set HOME_PATH as root url (index)
   if (ocularOptions.HOME_PATH) {
-    relPath = removeURLPath(relPath, ocularOptions.HOME_PATH);
+    relPath = removeURLPathPrefix(relPath, ocularOptions.HOME_PATH);
   }
   const docNode = docNodes[relPath] || null;
   if (!docNode || !docNode.id) {

--- a/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
@@ -5,6 +5,7 @@ const path = require('path');
 // TODO/ib - remove
 const _ = require('lodash');
 const {log, COLOR} = require('../../utils/log');
+const {removeURLPath} = require('../../utils/links-utils');
 
 function parseToc(queue, entry) {
   // this function returns a node in the TOC that has an entry corresponding to
@@ -56,6 +57,10 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
   basename = path.basename(basename, '.mdx');
   const dirname = path.dirname(relPath);
   relPath = basename === 'README' ? dirname : `${dirname}/${basename}`;
+  // remove part of the path to move root docs dir to index
+  if (ocularOptions.HOME_PATH) {
+    relPath = removeURLPath(relPath, ocularOptions.HOME_PATH);
+  }
 
   createNodeField({node, name: 'path', value: relPath});
   createNodeField({node, name: 'slug', value: relPath});

--- a/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
@@ -5,7 +5,7 @@ const path = require('path');
 // TODO/ib - remove
 const _ = require('lodash');
 const {log, COLOR} = require('../../utils/log');
-const {removeURLPath} = require('../../utils/links-utils');
+const {removeURLPathPrefix} = require('../../utils/links-utils');
 
 function parseToc(queue, entry) {
   // this function returns a node in the TOC that has an entry corresponding to
@@ -57,9 +57,9 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
   basename = path.basename(basename, '.mdx');
   const dirname = path.dirname(relPath);
   relPath = basename === 'README' ? dirname : `${dirname}/${basename}`;
-  // remove part of the path to move root docs dir to index
+  // remove prefix from the path to set HOME_PATH as root url (index)
   if (ocularOptions.HOME_PATH) {
-    relPath = removeURLPath(relPath, ocularOptions.HOME_PATH);
+    relPath = removeURLPathPrefix(relPath, ocularOptions.HOME_PATH);
   }
 
   createNodeField({node, name: 'path', value: relPath});

--- a/modules/gatsby-theme-ocular/src/gatsby-node/source-nodes.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/source-nodes.js
@@ -53,6 +53,7 @@ function sourceNodes({actions}) {
 
       PROJECT_URL: String
       WEBSITE_PATH: String
+      HOME_PATH: String
 
       HEADER_LINK_URL: String
 

--- a/modules/gatsby-theme-ocular/src/react/components/header.component.jsx
+++ b/modules/gatsby-theme-ocular/src/react/components/header.component.jsx
@@ -93,7 +93,7 @@ export function generateHeaderLinks(props) {
 
   const links = [
     exampleLink,
-    {label: 'Documentation', to: '/docs'},
+    {label: 'Documentation', to: config.HOME_PATH ? '/' : '/docs'},
     {label: 'Search', to: '/search'}
   ];
 

--- a/modules/gatsby-theme-ocular/src/react/components/markdown.jsx
+++ b/modules/gatsby-theme-ocular/src/react/components/markdown.jsx
@@ -30,9 +30,9 @@ import {
 
 import {parseLinks} from '../../utils/links-utils.js';
 
-const CustomLinkWrapper = (path, relativeLinks) => {
+const CustomLinkWrapper = (path, relativeLinks, config) => {
   const CustomLink = ({href, ...props}) => {
-    const updatedLink = parseLinks(href, path, relativeLinks);
+    const updatedLink = parseLinks(href, path, relativeLinks, config);
     return updatedLink ? <GatsbyA to={updatedLink} {...props} /> : <A href={href} {...props} />;
   };
   return CustomLink;
@@ -92,7 +92,7 @@ const CustomHeader = (ComponentType, id, props, anchors) => {
 }
 
 export default props => {
-  const {relativeLinks, path} = props;
+  const {relativeLinks, path, config} = props;
   // note - we can add many other custom components.
 
   const anchors = {};
@@ -117,7 +117,7 @@ export default props => {
     th: TableHeaderCell,
     td: TableBodyCell,
     blockquote: BlockQuote,
-    a: relativeLinks ? CustomLinkWrapper(path, relativeLinks) : A
+    a: relativeLinks ? CustomLinkWrapper(path, relativeLinks, config) : A
   };
 
   return <MDXProvider components={components} ><MDXRenderer>{props.body}</MDXRenderer></MDXProvider>;

--- a/modules/gatsby-theme-ocular/src/react/site-query.jsx
+++ b/modules/gatsby-theme-ocular/src/react/site-query.jsx
@@ -41,6 +41,7 @@ const QUERY = graphql`
           href
           index
         }
+        HOME_PATH
       }
     }
   }

--- a/modules/gatsby-theme-ocular/src/react/templates/documentation.jsx
+++ b/modules/gatsby-theme-ocular/src/react/templates/documentation.jsx
@@ -28,6 +28,7 @@ export default class DocTemplate extends React.Component {
         <MarkdownBody>
           <Markdown path={this.props.location.pathname}
             relativeLinks={relativeLinks}
+            config={this.props.config}
             body={body} />
         </MarkdownBody>
       </div>

--- a/modules/gatsby-theme-ocular/src/react/templates/top-level-layout.jsx
+++ b/modules/gatsby-theme-ocular/src/react/templates/top-level-layout.jsx
@@ -109,7 +109,7 @@ export default class Layout extends React.Component {
         </TocContainer>
 
         <BodyContainerToC>
-          {children}
+          {React.cloneElement(children, { config: config })}
         </BodyContainerToC>
         {/* <Footer /> */}
       </Body>
@@ -129,7 +129,9 @@ export default class Layout extends React.Component {
           />
         </HeaderContainer>
 
-        <BodyContainerFull>{children}</BodyContainerFull>
+        <BodyContainerFull>
+          {React.cloneElement(children, { config: config })}
+        </BodyContainerFull>
 
         {/* <Footer /> */}
       </Body>

--- a/modules/gatsby-theme-ocular/src/utils/links-utils.js
+++ b/modules/gatsby-theme-ocular/src/utils/links-utils.js
@@ -9,7 +9,7 @@ const parseLinks = (href, source, relativeLinks, config) => {
 
   let relPath = href.replace(/#.*/, '');
   if (config.HOME_PATH) {
-    relPath = removeURLPath(relPath, config.HOME_PATH);
+    relPath = removeURLPathPrefix(relPath, config.HOME_PATH);
   } else {
     relPath = linkFromFileToFile(source, relPath);
   }
@@ -82,7 +82,7 @@ function addToRelativeLinks({source, target, rootFolder, edge, relativeLinks}) {
   };
 }
 
-function removeURLPath(relPath, pathToRemove) {
+function removeURLPathPrefix(relPath, pathToRemove) {
   let result = relPath;
   if (relPath.includes(`/${pathToRemove}/`)) {
     result = relPath.replace(`/${pathToRemove}/`, '/');
@@ -106,4 +106,4 @@ function isInternalURL(to) {
 module.exports.addToRelativeLinks = addToRelativeLinks;
 module.exports.parseLinks = parseLinks;
 module.exports.isInternalURL = isInternalURL;
-module.exports.removeURLPath = removeURLPath;
+module.exports.removeURLPathPrefix = removeURLPathPrefix;

--- a/modules/gatsby-theme-ocular/src/utils/links-utils.js
+++ b/modules/gatsby-theme-ocular/src/utils/links-utils.js
@@ -1,13 +1,19 @@
 const path = require('path');
 const {log, COLOR} = require('./log');
 
-const parseLinks = (href, source, relativeLinks) => {
+const parseLinks = (href, source, relativeLinks, config) => {
   // external link
   if (href.startsWith('http') || href.startsWith('#')) {
     return null;
   }
 
-  const relPath = linkFromFileToFile(source, href.replace(/#.*/, ''));
+  let relPath = href.replace(/#.*/, '');
+  if (config.HOME_PATH) {
+    relPath = removeURLPath(relPath, config.HOME_PATH);
+  } else {
+    relPath = linkFromFileToFile(source, relPath);
+  }
+  
   const anchor = href.match(/#.*/);
   // relative link ie doc to doc
   const relativeLink = relativeLinks[relPath];
@@ -76,6 +82,18 @@ function addToRelativeLinks({source, target, rootFolder, edge, relativeLinks}) {
   };
 }
 
+function removeURLPath(relPath, pathToRemove) {
+  let result = relPath;
+  if (relPath.includes(`/${pathToRemove}/`)) {
+    result = relPath.replace(`/${pathToRemove}/`, '/');
+  } else if (relPath.includes(`${pathToRemove}/`)) {
+    result = relPath.replace(`${pathToRemove}/`, '');
+  } else if (relPath.includes(pathToRemove)) {
+    result = relPath.replace(pathToRemove, '/');
+  }
+  return result;
+}
+
 function isInternalURL(to) {
   try {
     const url = new URL(to, window.location.origin);
@@ -88,3 +106,4 @@ function isInternalURL(to) {
 module.exports.addToRelativeLinks = addToRelativeLinks;
 module.exports.parseLinks = parseLinks;
 module.exports.isInternalURL = isInternalURL;
+module.exports.removeURLPath = removeURLPath;

--- a/modules/gatsby-theme-ocular/test/index.js
+++ b/modules/gatsby-theme-ocular/test/index.js
@@ -5,3 +5,4 @@ require('reify');
 // start to import tests
 require('./utils/validate-config.spec.js');
 require('./utils/get-ocular-options.spec.js');
+require('./utils/links-utils.spec.js');

--- a/modules/gatsby-theme-ocular/test/utils/links-utils.spec.js
+++ b/modules/gatsby-theme-ocular/test/utils/links-utils.spec.js
@@ -1,0 +1,58 @@
+/* eslint-disable max-len */
+import test from 'tape-catch';
+import {removeURLPathPrefix} from '../../src/utils/links-utils';
+
+const HOME_PATH_DOCS = 'docs';
+const HOME_PATH_DOCUMENTATION = 'documentation';
+
+const URL_INPUTS = [
+  'docs/path1/path2/path3',
+  '/docs/path1/path2/path3',
+  '../../docs/path1/path2',
+  './docs/path1/path2',
+  'docs',
+  'documentation/path1/path2/path3',
+];
+
+const URL_INPUTS_RESULT = [
+  'path1/path2/path3',
+  '/path1/path2/path3',
+  '../../path1/path2',
+  './path1/path2',
+  '/',
+  'path1/path2/path3',
+];
+
+test('removeURLPathPrefix', t => {
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[0], HOME_PATH_DOCS),
+    URL_INPUTS_RESULT[0]
+  );
+
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[1], HOME_PATH_DOCS),
+    URL_INPUTS_RESULT[1]
+  );
+
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[2], HOME_PATH_DOCS),
+    URL_INPUTS_RESULT[2]
+  );
+
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[3], HOME_PATH_DOCS),
+    URL_INPUTS_RESULT[3]
+  );
+
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[4], HOME_PATH_DOCS),
+    URL_INPUTS_RESULT[4]
+  );
+
+  t.deepEquals(
+    removeURLPathPrefix(URL_INPUTS[5], HOME_PATH_DOCUMENTATION),
+    URL_INPUTS_RESULT[5]
+  );
+
+  t.end();
+});

--- a/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
+++ b/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
@@ -157,7 +157,7 @@ test('validateConfig', t => {
       },
       CONFIG_SCHEMA
     ),
-    [`Link to get started should be the path to the 'Get Started' doc, or default to '/docs'`],
+    [`Link to get started should be the path to the 'Get Started' doc. Defaults to '/docs/'`],
     `Check if LINK_TO_GET_STARTED is a valid string`
   );
 

--- a/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
+++ b/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
@@ -22,7 +22,7 @@ const GOOD_CONFIG = {
   PATH_PREFIX: '/ocular',
   PROJECT_ORG_LOGO: '',
   PROJECTS: [],
-  HOME_PATH: '/',
+  HOME_PATH: '',
   THEME_OVERRIDES: '',
 
   PAGES: [],

--- a/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
+++ b/modules/gatsby-theme-ocular/test/utils/validate-config.spec.js
@@ -12,7 +12,7 @@ const GOOD_CONFIG = {
   EXAMPLES: [],
   DOCS: {},
   HEADER_LINK_URL: '/',
-  LINK_TO_GET_STARTED: '',
+  LINK_TO_GET_STARTED: '/docs',
   PROJECT_TYPE: '',
   PROJECT_NAME: 'ocular',
   PROJECT_ORG: 'uber-web',
@@ -157,7 +157,7 @@ test('validateConfig', t => {
       },
       CONFIG_SCHEMA
     ),
-    [`Link to get started should be the path to the 'Get Started' doc, or default to '/docs/developer-guide/get-started'`],
+    [`Link to get started should be the path to the 'Get Started' doc, or default to '/docs'`],
     `Check if LINK_TO_GET_STARTED is a valid string`
   );
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -27,7 +27,6 @@ module.exports = {
       PROJECT_DESC: 'Uber\'s open source documentation system',
       PATH_PREFIX: '',
 
-      HOME_PATH: '/',
       LINK_TO_GET_STARTED: '/docs',
       PAGES: [
         {


### PR DESCRIPTION
Added the ability to select which docs directory will be the index page.

With `HOME_PATH` defined as `docs`, Gatsby build won't generate any index pages but set the `docs` page as the index one. This change is applied for both TOC and links.

Special complexity is the requirement to have the links available and working in GitHub too, so this way might not be the most efficient but since we don't have to support that on private repos if `HOME_PATH` is defined that type of routing is ignored.

@ibgreen @Pessimistress  Please review.