### PR TITLE
Support file extensions in Babel build

### DIFF
--- a/docs/dev-tools/README.md
+++ b/docs/dev-tools/README.md
@@ -87,6 +87,8 @@ A file `ocular-dev-tools.config.js` can be placed at the root of the package to 
 - `lint`
   + `paths` (Arrray) - directories to include when linting. Default `['modules', 'src']`
   + `extensions` (Array) - file extensions to include when linting. Default `['js', 'md']`
+- `babel`
+  + `extensions` - List of file extensions (prefixed with `.`) that `babel` will process. Default `['.es6', '.js', '.es', '.jsx', '.mjs']`
 - `aliases` (Object) - additional [module aliases](https://www.npmjs.com/package/module-alias) to use in tests. Default {}.
 - `entry` (Object) - entry points for tests.
   + `test` (String) - unit test entry point. Default `./test/index`.

--- a/modules/dev-tools/config/ocular.config.js
+++ b/modules/dev-tools/config/ocular.config.js
@@ -32,7 +32,8 @@ module.exports = (opts = {}) => {
         resolve(packageRoot, './babel.config.js'),
         resolve(packageRoot, './.babelrc'),
         resolve(__dirname, './babel.config.js')
-      ])
+      ]),
+      extensions: ['.es6', '.js', '.es', '.jsx', '.mjs']
     },
 
     lint: {

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -5,7 +5,7 @@ set -e
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".modules" | sed -E "s/,/ /g"`
-EXTENSIONS=".es6,.js,.es,.jsx,.mjs"
+EXTENSIONS=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.extensions"`
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then
@@ -47,9 +47,6 @@ build_monorepo() {
       case "$1" in
         --dist)
             TARGET=$2
-            shift ;;
-        --extensions)
-            EXTENSIONS=$2
             shift ;;
         *)
             echo -e "\033[91mUnknown option $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -5,12 +5,20 @@ set -e
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".modules" | sed -E "s/,/ /g"`
+EXTENSIONS=".js"
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then
     echo -e "\033[91mUnknown build target $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"
     exit 1
   fi
+}
+
+build_src() {
+  OUT_DIR=$1
+  TARGET=$2
+  check_target $TARGET
+  BABEL_ENV=$TARGET npx babel src --config-file $CONFIG --out-dir $OUT_DIR --copy-files --source-maps --extensions $EXTENSIONS
 }
 
 build_module() {
@@ -21,12 +29,10 @@ build_module() {
   fi
   N=`echo "$TARGETS" | wc -w`
   if [ $N -eq 1 ]; then
-    check_target $TARGETS
-    BABEL_ENV=$TARGETS npx babel src --config-file $CONFIG --out-dir dist --copy-files --source-maps
+    build_src dist $TARGETS
   else
     for T in ${TARGETS}; do(
-      check_target $T
-      BABEL_ENV=$T npx babel src --config-file $CONFIG --out-dir dist/$T --copy-files --source-maps
+       build_src dist/$T $T
     ); done
   fi
 }
@@ -41,6 +47,9 @@ build_monorepo() {
       case "$1" in
         --dist)
             TARGET=$2
+            shift ;;
+        --extensions)
+            EXTENSIONS=$2
             shift ;;
         *)
             echo -e "\033[91mUnknown option $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -5,7 +5,7 @@ set -e
 DEV_TOOLS_DIR=`node -e "require('ocular-dev-tools/node/module-dir')()"`
 CONFIG=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.configPath"`
 MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".modules" | sed -E "s/,/ /g"`
-EXTENSIONS=".js"
+EXTENSIONS=".es6,.js,.es,.jsx,.mjs"
 
 check_target() {
   if [[ ! "$1" =~ ^es5|es6|esm ]]; then


### PR DESCRIPTION
At present, it isn't possible to specify a custom list of file extensions to build in `babel.config.js` - see https://github.com/babel/babel/issues/8652. There's an [open PR](https://github.com/babel/babel/pull/12216) for this support in Babel, but at the moment the only way to convince the Babel CLI to parse files with extensions other than `.js` and `.jsx` is to provide the list on the command line.

This PR adds support for custom extensions via `ocular build --extensions ".js,.ts"`, allowing the use of `ocular-dev-tools` for Typescript via `@babel/preset-typescript`.