### PR TITLE
Fix ToC node backfill and doc page creation export

### DIFF
--- a/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-doc-pages.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/create-pages/create-doc-pages.js
@@ -93,5 +93,5 @@ module.exports = function createDocPages({graphql, actions}, ocularOptions) {
     `Creating docs pages...`
   )();
 
-  createDocMarkdownPages({graphql, actions}, ocularOptions);
+  return createDocMarkdownPages({graphql, actions}, ocularOptions);
 };

--- a/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-node/on-create-node/process-nodes-markdown.js
@@ -57,6 +57,10 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
   basename = path.basename(basename, '.mdx');
   const dirname = path.dirname(relPath);
   relPath = basename === 'README' ? dirname : `${dirname}/${basename}`;
+
+  // Store the path before potentially modifying as we want to keep the HOME_PATH for ToC lookup
+  const tocNodePath = relPath;
+  
   // remove prefix from the path to set HOME_PATH as root url (index)
   if (ocularOptions.HOME_PATH) {
     relPath = removeURLPathPrefix(relPath, ocularOptions.HOME_PATH);
@@ -76,7 +80,7 @@ module.exports.processNewMarkdownNode = function processNewMarkdownNode(
     // we don't need as much. The app will only use the title and slug of the corresponding markdown
     // node for each toc entry.
 
-    const nodeToEdit = parseToc([tocNode], relPath);
+    const nodeToEdit = parseToc([tocNode], tocNodePath);
     if (nodeToEdit) {
       nodeToEdit.childMdx = {
         fields: {


### PR DESCRIPTION
Fixes two issues that we ran into:
- In case where `Mdx` node gets created after table of contents (`DocsJson` node) is created, table of contents backfill did not work when `HOME_PATH` is specified. `tocNode` entries contain paths that don't have `HOME_PATH` prefix stripped (I assume it should remain that way), and it was being compared with relative path after the prefix has been removed
- `createDocPages` was not returning a promise, making `Promise.all` in `create-pages` resolve `docPromise` which is `undefined` immediately. This (sometimes) results in a warning message, noting that `createPage` is getting called inappropriately

On a side-note -- there is a comment in `on-create-node.js` noting that globals shouldn't be used to keep track of nodes in order to match them with ToC contents. Would it be possible to do node processing in `sourceNodes` instead of `onCreateNode`? Per docs, all the nodes will be present when `sourceNodes` is called, versus `onCreateNode` being called whenever each new node is created. That would allow for some cleanup as explicit handling for these race conditions would not be needed
