### PR TITLE
gatsby-theme-ocular@1.2.4

### DIFF
--- a/modules/gatsby-theme-ocular/CHANGELOG.md
+++ b/modules/gatsby-theme-ocular/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG (gatsby-theme-ocular)
 
+## 1.2.4
+- Fix `createDocPages` not returning a Promise (#342)
+- Fix table of contents backfill when `HOME_PATH` is used (#342)
+
 ## v1.2.3
 - Fix page styling on mobile (#337)
 - fix link mapping from README.md (#338)

--- a/modules/gatsby-theme-ocular/package.json
+++ b/modules/gatsby-theme-ocular/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-theme-ocular",
   "description": "GatsbyJS theme handling markdown docs and examples for frameworks.",
   "private": false,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump `gatsby-theme-ocular` version to `1.2.4`. Depends on #342