### PR TITLE
Support custom tag in publish script

### DIFF
--- a/docs/dev-tools/cli/ocular-publish.md
+++ b/docs/dev-tools/cli/ocular-publish.md
@@ -6,15 +6,19 @@ Publish the packages, create git tag and push.
 
 This script will usually be mapped to `publish`:
 ```bash
-yarn publish [mode]
+yarn publish [mode] [npm-tag]
 ```
 
 To run it directly
 ```bash
-npx ocular-publish [mode]
+npx ocular-publish [mode] [npm-tag]
 ```
 
-## Modes
+## mode
 
 - `beta` - bump pre-release version and publish with beta flag.
 - `prod` - bump patch version and publish.
+
+## npm-tag
+
+Custom tag for the release. If not specified, the release is tagged with `beta` if `mode: beta` and `latest` if `mode: prod`.

--- a/modules/dev-tools/scripts/publish.sh
+++ b/modules/dev-tools/scripts/publish.sh
@@ -16,6 +16,8 @@ ocular-test dist
 
 # beta or prod
 MODE=$1
+# custom tag
+TAG=$2
 
 if [ -d "modules" ]; then
   case $MODE in
@@ -26,11 +28,22 @@ if [ -d "modules" ]; then
     "beta")
       # npm-tag argument: npm publish --tag <beta>
       # cd-version argument: increase <prerelease> version
-      lerna publish --force-publish --exact --npm-tag beta --cd-version prerelease
+      if [ -z "$TAG" ]
+      then
+        lerna publish --force-publish --exact --npm-tag beta --cd-version prerelease
+      else
+        lerna publish --force-publish --exact --npm-tag $TAG --cd-version prerelease
+      fi
       ;;
 
     "prod")
-      lerna publish --force-publish --exact --cd-version patch
+      if [ -z "$TAG" ]
+      then
+        # latest
+        lerna publish --force-publish --exact --cd-version patch
+      else
+        lerna publish --force-publish --exact --npm-tag $TAG --cd-version patch
+      fi
       ;;
 
     *)
@@ -48,7 +61,12 @@ else
       npm version prerelease --force
       # push to branch
       git push && git push --tags
-      npm publish --tag beta
+      if [ -z "$TAG" ]
+      then
+        npm publish --tag beta
+      else
+        npm publish --tag $TAG
+      fi
       ;;
 
     "prod")
@@ -56,7 +74,14 @@ else
       npm version patch --force
       # push to branch
       git push && git push --tags
-      npm publish
+
+      if [ -z "$TAG" ]
+      then
+        # latest
+        npm publish
+      else
+        npm publish --tag $TAG
+      fi
       ;;
 
     *)


### PR DESCRIPTION
### Background

react-map-gl is maintaining two parallel release tracks (mapbox v1/v2) and they should not be both tagged `latest`.

### Change List

Support custom npm tag in publish script