### PR TITLE
[dev-tools] Change build targets

### DIFF
--- a/docs/dev-tools/cli/ocular-build.md
+++ b/docs/dev-tools/cli/ocular-build.md
@@ -1,3 +1,7 @@
 # ocular-build
 
-Build the src
+Build the source.
+
+```bash
+ocular-build [module_name]
+```

--- a/docs/dev-tools/developer-guide/configuring-tests.md
+++ b/docs/dev-tools/developer-guide/configuring-tests.md
@@ -8,29 +8,16 @@ There are some things that may need to be configured:
 
 ### Using import/export
 
-The first thing you usually need to address is to sing import/export in Node.js requires taking extra steps
+The first thing you usually need to address is to sing import/export in Node.js requires taking extra steps.
 
-While Node 12 will soon enable `import`/`export` by default, you will typically want to at least add support for `import`/`export` under Node.js
+While Node 13 supports `import`/`export` by default, it requires:
+- a [type](https://nodejs.org/api/packages.html#packages_determining_module_system) field in every `package.json` that matches the module type. This becomes tricky when you import from a npm package that is missing this field.
+- the whole repo to use one of esm module or commonjs style
 
-Two tested options are:
-
-* `require('reify')` - This makes Node.js understand `import`/`export`, but otherwise does not transpile your code. This is a great option if you want to test your source code directly, either because you want to debug untranspiled code, or you want to ensure that your code runs untranspiled to ensure you don't use unsupported syntax. You can simply require `reify` at the entry point of your test. Note that you cannot use import in the same file, only inside files required after requiring reify.
-
-```
-// test/index.js
-require('reify');
-
-// start to require your tests
-require('./test1.js');
-
-```
-
-* `require('@babel/register')` - This option runs the babel transpiler. This is ideal if you want to use non-standard syntax such as stage-x babel plugins, flow etc.
-
-You can import `@bable/register`, and that is how babel config is accessed in dev mode. Unless that module is imported, no transpilation is done on your source.
+Alternatively, you may use `require('@babel/register')` - This option runs the babel transpiler. The default babel config transforms all code for Node.js >=14, which allows the usage of import/export without too much meddling with the source code.
 
 You may also manually set the `BABEL_ENV` environment variable when running your test command to control which config to use.
 
 ```sh
-BABEL_ENV=es6 yarn test
+BABEL_ENV=es5 yarn test
 ```

--- a/modules/dev-tools/config/babel.config.js
+++ b/modules/dev-tools/config/babel.config.js
@@ -1,10 +1,11 @@
 // The following targets are designed to support the most commonly used evergreen browsers.
 // As of Feb 2021 they all support async function, async iterator, and spread operator.
 const TARGETS = [
-  ">0.2%",
-  "not ie 11",
-  "not dead",
-  "not chrome 49"
+  '>0.2%',
+  'maintained node versions',
+  'not ie 11',
+  'not dead',
+  'not chrome 49'
 ];
 
 const COMMON_CONFIG = {
@@ -37,7 +38,7 @@ const ENV_CONFIG = {
   test: {
     presets: [
       [ '@babel/preset-env', {
-        targets: {node: '14'}
+        targets: 'maintained node versions'
       }]
     ],
     plugins: [

--- a/modules/dev-tools/config/babel.config.js
+++ b/modules/dev-tools/config/babel.config.js
@@ -1,19 +1,11 @@
-// The goal of the `es6` target is a very clean build (minimally transformed).
-// - It is intended to enable debugging using non-transpiled code.
-// - It intentionally runs on recent browsers only.
-//
-// In particular, it does not transform async/await constructs, which is very helpful when debugging
-// Because of this, we only try to support ~1 year old browsers + Node LTS
-// Including older versions dramatically increases the number of transforms preset-env will apply
-// Note: uncomment `debug` flag in preset env to see what gets included
-const ES6_TARGETS = {
-  chrome: '79', // Released: 2019-Dec-10, https://en.wikipedia.org/wiki/Google_Chrome_version_history
-  edge: '79', // Released: 2020-Jan-15, https://en.wikipedia.org/wiki/Microsoft_Edge
-  firefox: '68', // Released: 2019-Jul-9, https://en.wikipedia.org/wiki/Firefox_version_history
-  safari: '12', // Released: 2018-09-07 (OSX Mojave) - https://en.wikipedia.org/wiki/Safari_version_history
-  ios: '12', // Track Safari
-  node: '10' // Node 8 LTS expired December 31, 2019.
-};
+// The following targets are designed to support the most commonly used evergreen browsers.
+// As of Feb 2021 they all support async function, async iterator, and spread operator.
+const TARGETS = [
+  ">0.2%",
+  "not ie 11",
+  "not dead",
+  "not chrome 49"
+];
 
 const COMMON_CONFIG = {
   comments: false
@@ -23,7 +15,7 @@ const ENV_CONFIG = {
   es5: {
     presets: [
       [ '@babel/env', {
-        forceAllTransforms: true,
+        targets: TARGETS,
         modules: 'commonjs'
       }]
     ],
@@ -34,23 +26,8 @@ const ENV_CONFIG = {
   esm: {
     presets: [
       [ '@babel/env', {
-        forceAllTransforms: true,
+        targets: TARGETS,
         modules: false
-      }]
-    ],
-    plugins: [
-      ['@babel/transform-runtime', {useESModules: true}]
-    ]
-  },
-  es6: {
-    presets: [
-      [ '@babel/env', {
-        targets: ES6_TARGETS,
-        // debug: true, // shows which plugins are selected by targets
-        modules: false,
-        exclude: [
-          "@babel/plugin-transform-regenerator"
-        ]
       }]
     ],
     plugins: [
@@ -59,7 +36,9 @@ const ENV_CONFIG = {
   },
   test: {
     presets: [
-      '@babel/preset-env'
+      [ '@babel/preset-env', {
+        targets: {node: '14'}
+      }]
     ],
     plugins: [
       'istanbul'

--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -8,8 +8,8 @@ MODULES=`node $DEV_TOOLS_DIR/node/get-config.js ".modules" | sed -E "s/,/ /g"`
 EXTENSIONS=`node $DEV_TOOLS_DIR/node/get-config.js ".babel.extensions"`
 
 check_target() {
-  if [[ ! "$1" =~ ^es5|es6|esm ]]; then
-    echo -e "\033[91mUnknown build target $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"
+  if [[ ! "$1" =~ ^es5|esm ]]; then
+    echo -e "\033[91mUnknown build target $1. ocular-build [--dist es5|esm,...] [module1,...]\033[0m"
     exit 1
   fi
 }
@@ -23,7 +23,7 @@ build_src() {
 
 build_module() {
   if [ -z "$1" ]; then
-    TARGETS="es6 esm es5"
+    TARGETS="esm es5"
   else
     TARGETS=$*
   fi
@@ -49,7 +49,7 @@ build_monorepo() {
             TARGET=$2
             shift ;;
         *)
-            echo -e "\033[91mUnknown option $1. ocular-build [--dist es5|es6|esm,...] [module1,...]\033[0m"
+            echo -e "\033[91mUnknown option $1. ocular-build [--dist es5|esm,...] [module1,...]\033[0m"
             exit 1 ;;
       esac
     else

--- a/modules/dev-tools/scripts/clean.sh
+++ b/modules/dev-tools/scripts/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 clean() {
   if [ -z "$1" ]; then
-    rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6
+    rm -fr dist && mkdir -p dist/es5 dist/esm
   elif [ "$1" = "all" ]; then
     rm -fr dist
   else


### PR DESCRIPTION
### This is a breaking change

- Drop support for IE and other obsolete browsers from ES5 and ESM targets - this saves about 20% off the transpiled bundle size
- Drop the ES6 dist target (less aggressive than the new ESM target) - we have been using this with the `esnext` field which is not a standard entry point
- Default babel config for unit tests now require Node.js >=10.24 - this is independent of the above changes and open for discussion. 10 is the smallest [maintained release](https://nodejs.org/en/about/releases/) and the first release that supports async functions.