### PR TITLE
For ES Modules: Look also for .ocularrc.cjs

### DIFF
--- a/docs/dev-tools/README.md
+++ b/docs/dev-tools/README.md
@@ -98,7 +98,7 @@ module.exports = env => {
 
 #### ocular-dev-tools.js
 
-A file `ocularrc.js` can be placed at the root of the package to customize the dev scripts. The config file may export a JSON object that contains the following keys, or a callback function that returns such object:
+A file `.ocularrc.js` (or `.ocularrc.cjs` for `type:module` projects) can be placed at the root of the package to customize the dev scripts. The config file may export a JSON object that contains the following keys, or a callback function that returns such object:
 
 - `lint`
   + `paths` (Arrray) - directories to include when linting. Default `['modules', 'src']`

--- a/modules/dev-tools/src/helpers/get-ocular-config.js
+++ b/modules/dev-tools/src/helpers/get-ocular-config.js
@@ -85,7 +85,7 @@ function getUserConfig(packageRoot, options) {
       userConfig = userConfig(options);
     }
   }
-  // Backeward compatibility
+  // Backward compatibility
   userConfigPath = resolve(packageRoot, './ocular.config.js');
   if (fs.existsSync(userConfigPath)) {
     userConfig = require(userConfigPath);

--- a/modules/dev-tools/src/helpers/get-ocular-config.js
+++ b/modules/dev-tools/src/helpers/get-ocular-config.js
@@ -76,6 +76,13 @@ function getUserConfig(packageRoot, options) {
       userConfig = userConfig(options);
     }
   }
+  userConfigPath = resolve(packageRoot, './.ocularrc.cjs');
+  if (fs.existsSync(userConfigPath)) {
+    userConfig = require(userConfigPath);
+    if (typeof userConfig === 'function') {
+      userConfig = userConfig(options);
+    }
+  }
   userConfigPath = resolve(packageRoot, './ocular.config.js');
   if (fs.existsSync(userConfigPath)) {
     userConfig = require(userConfigPath);

--- a/modules/dev-tools/src/helpers/get-ocular-config.js
+++ b/modules/dev-tools/src/helpers/get-ocular-config.js
@@ -69,6 +69,7 @@ function getUserConfig(packageRoot, options) {
 
   let userConfigPath;
 
+  // Standard config file
   userConfigPath = resolve(packageRoot, './.ocularrc.js');
   if (fs.existsSync(userConfigPath)) {
     userConfig = require(userConfigPath);
@@ -76,6 +77,7 @@ function getUserConfig(packageRoot, options) {
       userConfig = userConfig(options);
     }
   }
+  // Compatibility with type:module packages
   userConfigPath = resolve(packageRoot, './.ocularrc.cjs');
   if (fs.existsSync(userConfigPath)) {
     userConfig = require(userConfigPath);
@@ -83,6 +85,7 @@ function getUserConfig(packageRoot, options) {
       userConfig = userConfig(options);
     }
   }
+  // Backeward compatibility
   userConfigPath = resolve(packageRoot, './ocular.config.js');
   if (fs.existsSync(userConfigPath)) {
     userConfig = require(userConfigPath);


### PR DESCRIPTION
Hi! When working with a package that is defined as an ES module (`"type":"module"`, now [supported natively by Node 12 LTS](https://blog.sindresorhus.com/hello-modules-d1010b4e777b)), I get the following error:
```
Error: [ERR_REQUIRE_ESM]: Must use import to load ES Module: /****/.ocularrc.js
  require() of ES modules is not supported.
  require() of /***/node_modules/ocular-dev-tools/src/helpers/get-ocular-config.js is an ES module file 
as it is a .js file whose nearest parent package.json contains "type": "module" which defines all 
.js files in that package scope as ES modules.   Instead rename .ocularrc.js to end in .cjs, 
change the requiring code to use import(), or remove "type": "module" from /**/package.json.
 ```
I figured the easiest way to handle this is to add another search path option: `.ocularrc.cjs` (for example it is supported in [eslint](https://eslint.org/docs/user-guide/configuring/configuration-files)).  This PR fixed the problem for me, after I renamed `.ocularrc.js` to `ocularrc.cjs`.