### PR TITLE
chore: update browser list on `yarn bootstrap`

### DIFF
--- a/modules/dev-tools/scripts/bootstrap.sh
+++ b/modules/dev-tools/scripts/bootstrap.sh
@@ -7,6 +7,10 @@ set -e
 yarn global add puppeteer
 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn
 
+# update browserlist database
+npx browserslist@latest --update-db
+
+# prepare module directories
 PACKAGE_DIR=`pwd`
 ROOT_NODE_MODULES_DIR=$PACKAGE_DIR/node_modules
 


### PR DESCRIPTION
- Make sure we are always seeing the same browser versions
- Unfortunately the database update is quite slow, adding 10-20 seconds to what is already a 14 minute CI run.
- I assume specifying actual browser versions would reduce the need for this step.