### PR TITLE
feat(dev-tools): Partial webpack 5 support

### DIFF
--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -88,6 +88,12 @@
     "webpack-dev-server": "^3.1.14",
     "webpack": "^4.28.4"
   },
+  "dependencies-webpack4-comment": {
+    "webpack-bundle-analyzer": "^4.4.1",
+    "webpack": "5.38.1",
+    "webpack-cli": "4.7.0",
+    "webpack-dev-server": "4.0.0-beta.3"
+  },
   "devDependencies": {
     "@probe.gl/test-utils": "^3.0.2",
     "math.gl": "^3.0.0"

--- a/modules/dev-tools/src/helpers/get-ocular-config.d.ts
+++ b/modules/dev-tools/src/helpers/get-ocular-config.d.ts
@@ -1,5 +1,7 @@
 /** Helper type to typecheck ocular config in applications */
 type OcularConfig = {
+  aliases?: {[module: string]: string},
+
   babel?: {
     configPath?: string;
     extensions?: string[];
@@ -10,7 +12,15 @@ type OcularConfig = {
     extensions?: string[];
   },
 
-  aliases?: {[module: string]: string},
+  webpack?: {
+    version?: number;
+    configPath?: string;
+  };
+
+  browserTest?: {
+    server?: string;
+    browser?: string;
+  };
 
   entry?: {
     test?: string;
@@ -19,15 +29,12 @@ type OcularConfig = {
     'bench-browser'?: string;
     size?: string;
   };
-
-  webpack?: {
-    version?: number;
-    configPath?: string;
-  };
 }
 
 /** Internal type to typecheck resolved ocular config inside ocular-dev-tools */
 type MaterializedOcularConfig = {
+  aliases: {[module: string]: string},
+
   babel: {
     configPath: string;
     extensions: string[];
@@ -38,7 +45,15 @@ type MaterializedOcularConfig = {
     extensions: string[];
   },
 
-  aliases: {[module: string]: string},
+  webpack: {
+    version: number;
+    configPath: string;
+  };
+
+  browserTest?: {
+    server?: string;
+    browser?: string;
+  };
 
   entry: {
     test: string;
@@ -46,11 +61,6 @@ type MaterializedOcularConfig = {
     bench: string;
     'bench-browser': string;
     size: string;
-  };
-
-  webpack?: {
-    version?: number;
-    configPath?: string;
   };
 }
 

--- a/modules/dev-tools/test/browser.js
+++ b/modules/dev-tools/test/browser.js
@@ -1,0 +1,1 @@
+import './lib/utils.spec';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,6 @@ module.exports = (env = {}) => {
   const config = getWebpackConfig(env);
 
   // Make any changes to default config here
-  // https://github.com/prettier/prettier/issues/4879
-  console.error(env);
-  delete config.node.fs;
 
   // Uncomment to debug config
   // console.error(JSON.stringify(config, null, 2));


### PR DESCRIPTION
Adds new flag to ocularrc.js: `webpack.version`.

Generates updated webpack config in this case.

Still haven't been able to get BrowserTestDriver working so still installing webpack 4.

@ilijapuaca 