### PR TITLE
chore(gatsby): Reorder page title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,7 @@ While highly configurable ocular-dev-tools is very opinionated in choice of tool
 
 ## About gatsby-theme-ocular
 
-<<<<<<< HEAD
 The vis.gl team needed a system to build documentation websites with the least amount of friction. Our first use case has been the websites for the various visualization projects such as [deck.gl](https://deck.gl) [luma.gl](https://luma.gl) or [loaders.gl](https://loaders.gl). 
-=======
-The vis.gl team needed a system to build documentation websites with the least amount of friction. Our first use case has been the websites for the various visualization projects such as [deck.gl](https://deck.gl) [luma.gl](https://luma.gl) or [loaders.gl](https://loaders.gl).
->>>>>>> chore(docs): Split docs per module
 
 We wanted: 
 - to organize documentation files with a table of contents, navigation and search;

--- a/modules/gatsby-theme-ocular/docs/creating-content/interactive-examples.mdx
+++ b/modules/gatsby-theme-ocular/docs/creating-content/interactive-examples.mdx
@@ -1,4 +1,4 @@
-import App from '../../../examples/minimal/app';
+import App from '../../../../examples/dev-tools/src/app';
 
 # Interactive Examples
 

--- a/modules/gatsby-theme-ocular/src/react/templates/top-level-layout.jsx
+++ b/modules/gatsby-theme-ocular/src/react/templates/top-level-layout.jsx
@@ -151,7 +151,7 @@ export default class Layout extends React.Component {
     const theme = this.getTheme();
     let title = config.PROJECT_NAME;
     if (pageContext.title) {
-      title += ` | ${pageContext.title}`;
+      title = `${pageContext.title} | ${title}`;
     }
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,9 +5071,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001246"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz"
-  integrity sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==
+  version "1.0.30001247"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz"
+  integrity sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==
 
 capture-exit@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
As per discussion with @ibgreen I re-ordered the page title to now be in the format of `Page name - Site name`.

Also when trying to test this with the ocular website I noticed there were some dependancies that had incorrect paths that prevented the build of the website.
Also a minor merge conflict leftover in one markdown file.