### PR TITLE
fix(gatsby): Ignore tsconfig.json

### DIFF
--- a/modules/gatsby-theme-ocular/CHANGELOG.md
+++ b/modules/gatsby-theme-ocular/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##
 
-- fix(gatsby): Ignore tsconfig.json
+- fix(gatsby): Ignore tsconfig.json (#379)
 - chore(gatsby): Reorder page title (#377)
 - chore: align gatsby module with dev-tools (#359)
 

--- a/modules/gatsby-theme-ocular/CHANGELOG.md
+++ b/modules/gatsby-theme-ocular/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG (gatsby-theme-ocular)
 
+##
+
+- fix(gatsby): Ignore tsconfig.json
+- chore(gatsby): Reorder page title (#377)
+- chore: align gatsby module with dev-tools (#359)
+
+
 ## 1.2.4
 
 - Fix `createDocPages` not returning a Promise (#342)

--- a/modules/gatsby-theme-ocular/package.json
+++ b/modules/gatsby-theme-ocular/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-theme-ocular",
   "description": "GatsbyJS theme handling markdown docs and examples for frameworks.",
   "private": false,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
+++ b/modules/gatsby-theme-ocular/src/gatsby-config/get-gatsby-config.js
@@ -4,6 +4,15 @@ const {log, COLOR} = require('../utils/log');
 const validateConfig = require('../utils/validate-config');
 const CONFIG_SCHEMA = require('./config-schema');
 
+const GATSBY_SOURCE_IGNORE_FILES = [
+  '**/src/**',
+  '**/test/**',
+  '**/dist/**',
+  '**/package.json',
+  '**/tsconfig.json',
+  '**/*.js'
+];
+
 const defaults = {
   logLevel: 3,
   DOC_FOLDERS: [],
@@ -162,7 +171,7 @@ module.exports = function getGatsbyConfig(config) {
           path,
           // Ensure gatsby-source-filesystem doesn't pick up too many files in modules directory
           // https://www.gatsbyjs.org/packages/gatsby-source-filesystem/#options
-          ignore: ['**/src/**', '**/test/**', '**/dist/**', '**/package.json', '**/*.js']
+          ignore: GATSBY_SOURCE_IGNORE_FILES
         }
       });
     }


### PR DESCRIPTION
Fix: Gatsby is picking up the tsconfig.json files inside each module (from typescript monorepo setups)

@belom88