### PR TITLE
[dev-tools] edge case handling and more flexible configs

### DIFF
--- a/modules/dev-tools/node/aliases.js
+++ b/modules/dev-tools/node/aliases.js
@@ -40,7 +40,7 @@ function getSubmodules(packageRoot) {
   return submodules;
 }
 
-function getAliases(mode = 'src', packageRoot = process.env.PWD) {
+function getAliases(mode, packageRoot = process.env.PWD) {
   const aliases = {};
   const submodules = getSubmodules(packageRoot);
 
@@ -51,7 +51,7 @@ function getAliases(mode = 'src', packageRoot = process.env.PWD) {
       const subPath = packageInfo.main && packageInfo.main.replace('/index.js', '');
       aliases[moduleName] = subPath ? resolve(path, subPath) : path;
     } else {
-      aliases[moduleName] = resolve(path, mode); // e.g 'src'
+      aliases[moduleName] = resolve(path, 'src');
     }
   }
 

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -58,7 +58,7 @@
     "@babel/runtime": "7.14.5",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
-    "@probe.gl/test-utils": "^3.0.2",
+    "@probe.gl/test-utils": "^3.5.4",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "babel-loader": "8.2.2",

--- a/modules/dev-tools/scripts/metrics.sh
+++ b/modules/dev-tools/scripts/metrics.sh
@@ -13,6 +13,7 @@ TMP_DIR=$WORKING_DIR/tmp
 ENTRY_POINTS=`node $DEV_TOOLS_DIR/node/get-config.js ".entry.size"`
 IFS=','
 read -a ENTRY_POINTS_ARR <<< "$ENTRY_POINTS"
+IFS=' '
 
 # Get name from package.json
 module=`node -e "console.log(require('./package.json').name)"`
@@ -57,9 +58,9 @@ print_size() {
 
 build_bundle() {
   if [ "$2" == es5 ]; then
-    DIST=main
+    DIST="main,module"
   else
-    DIST=module
+    DIST="module,browser,main"
   fi
   (esbuild $1 --outdir="$TMP_DIR" --bundle --minify --main-fields=$DIST --log-level=error)
 }

--- a/modules/dev-tools/src/helpers/get-ocular-config.d.ts
+++ b/modules/dev-tools/src/helpers/get-ocular-config.d.ts
@@ -4,6 +4,8 @@ type OcularConfig = {
 
   aliases?: {[module: string]: string};
 
+  nodeAliases?: {[module: string]: string};
+
   babel?: {
     configPath?: string;
     extensions?: string[];
@@ -36,6 +38,7 @@ type OcularConfig = {
 /** Internal type to typecheck resolved ocular config inside ocular-dev-tools */
 type MaterializedOcularConfig = {
   root: string;
+  ocularPath: string;
 
   aliases: {[module: string]: string};
 

--- a/modules/dev-tools/src/helpers/get-ocular-config.js
+++ b/modules/dev-tools/src/helpers/get-ocular-config.js
@@ -7,11 +7,13 @@ const {shallowMerge} = require('../utils/utils');
 
 module.exports.getOcularConfig = function getOcularConfig(options = {}) {
   const packageRoot = options.root || process.env.PWD;
+  const ocularRoot = resolve(__dirname, '../..');
 
   const IS_MONOREPO = fs.existsSync(resolve(packageRoot, './modules'));
 
   const config = {
     root: packageRoot,
+    ocularPath: ocularRoot,
 
     babel: {
       configPath: getValidPath([
@@ -41,7 +43,7 @@ module.exports.getOcularConfig = function getOcularConfig(options = {}) {
       version: 4,
       configPath: getValidPath([
         resolve(packageRoot, './vite.config.js'),
-        resolve(__dirname, '../configuration/vite.config.js')
+        resolve(ocularRoot, 'src/configuration/vite.config.js')
       ])
     }
   };
@@ -59,6 +61,10 @@ module.exports.getOcularConfig = function getOcularConfig(options = {}) {
 
   // User's aliases need to come first, due to module-alias resolve order
   Object.assign(config.aliases, getAliases(aliasMode, packageRoot));
+
+  if (aliasMode && !aliasMode.includes('browser')) {
+    Object.assign(config.aliases, userConfig.nodeAliases);
+  }
 
   return config;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -20108,7 +20108,19 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
 
-ts-node@^10.9.1:
+ts-node@^9:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
+ts-node@~10.9.0:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -20125,18 +20137,6 @@ ts-node@^10.9.1:
     diff "^4.0.1"
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
-ts-node@^9:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
-  dependencies:
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
 ts-pnp@^1.1.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,13 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+"@probe.gl/env@3.5.4":
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-3.5.4.tgz#faddd1232f607b634fa9f00502b40706e143426d"
+  integrity sha512-MtMINUpcPzAp8upQNbm5U1Hp+/EQ8yw0tXccg5Aiz7cl92LsMopDPtgXnCRv2whzcayioHAdg4YIhNPY5fFxMQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 "@probe.gl/log@3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-3.5.2.tgz#e33103f6151c30431c4bfe63f1341bc0d9febe94"
@@ -2956,6 +2963,14 @@
     "@babel/runtime" "^7.0.0"
     "@probe.gl/env" "3.5.2"
 
+"@probe.gl/log@3.5.4":
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-3.5.4.tgz#106c863032242ba1232d7a1afc4acd9905305305"
+  integrity sha512-jnyr6aAdW4PbS55izskE8crpb52hJ/bQwqeJeQywK6sm7Jhh9im2RFbPrjs8CIEVDBqrcwJ1Rm1hEvTKNhKSmA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@probe.gl/env" "3.5.4"
+
 "@probe.gl/stats@3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@probe.gl/stats/-/stats-3.5.2.tgz#8ee41f73199182fddb8e40221da967414eaea619"
@@ -2963,13 +2978,13 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@probe.gl/test-utils@^3.0.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-3.5.2.tgz#22ef9b8d5e3ff8eb89d9e658d643c901eb53f333"
-  integrity sha512-h82sbwQuhUKcXFZQIm+CzvxJ3QveOSd/ogH9DyLukbSnu6mFsFCE5Y6snrJ/eN/sz8TEwDrPJ0DtjjdOpiJVVA==
+"@probe.gl/test-utils@^3.5.4":
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-3.5.4.tgz#8e79b2eb68b07865d79708e1cf7895f0616ed88e"
+  integrity sha512-NV0esSd6YBDsyMuBkJblCIqtW+XNn3pmDhBe6jPR05xQZo40zcp4xJr/6Nxsw/ZRJU3qeIdG9j3doK+WriTpog==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/log" "3.5.2"
+    "@probe.gl/log" "3.5.4"
     pixelmatch "^4.0.2"
     puppeteer "*"
 


### PR DESCRIPTION
- Add new config `nodeAliases` for node-only replacements
- Fix `metrics` script
- Vite config supports both `.ts` and `.html` entry points 