### PR TITLE
[dev-tools] support for ESM repos (3/n) 

### DIFF
--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -65,6 +65,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "babel-loader": "8.2.2",
+    "babel-plugin-add-import-extension": "^1.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-version-inline": "^1.0.0",
     "c8": "^7.12.0",

--- a/modules/dev-tools/scripts/clean.sh
+++ b/modules/dev-tools/scripts/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 clean() {
   if [ -z "$1" ]; then
-    (set -x; rm -fr dist && mkdir -p dist/es5 dist/esm)
+    (set -x; rm -fr dist && mkdir -p dist)
   elif [ "$1" = "all" ]; then
     (set -x; rm -fr dist)
   else

--- a/modules/dev-tools/src/configuration/get-babel-config.cjs
+++ b/modules/dev-tools/src/configuration/get-babel-config.cjs
@@ -58,18 +58,24 @@ const ENV_CONFIG = {
       ['@babel/transform-runtime', {useESModules: true}]
     ]
   },
-  // coverage build (node only)
-  test: {
+
+  'esm-strict': {
     presets: [
       ...COMMON_PRESETS,
       [
-        '@babel/preset-env',
+        '@babel/env',
         {
-          targets: 'maintained node versions'
+          targets: ESM_TARGETS,
+          modules: false
         }
       ]
     ],
-    plugins: [...COMMON_PLUGINS, 'istanbul']
+    plugins: [
+      ...COMMON_PLUGINS,
+      "babel-plugin-add-import-extension",
+      // TODO - we likely do not need runtime transforms for the esm setting
+      ['@babel/transform-runtime', {useESModules: true}]
+    ]
   }
 };
 

--- a/modules/dev-tools/src/helpers/aliases.js
+++ b/modules/dev-tools/src/helpers/aliases.js
@@ -49,7 +49,7 @@ export default function getAliases(mode, packageRoot = process.env.PWD) {
     const {path, packageInfo} = submodules[moduleName];
     aliases[`${moduleName}/test`] = resolve(path, 'test');
     if (mode === 'dist') {
-      const subPath = packageInfo.main && packageInfo.main.replace('/index.js', '');
+      const subPath = packageInfo.main && packageInfo.main.replace(/\/[^\/]+$/, '');
       aliases[moduleName] = subPath ? resolve(path, subPath) : path;
     } else {
       aliases[moduleName] = resolve(path, 'src');

--- a/modules/dev-tools/src/helpers/esm-loader.js
+++ b/modules/dev-tools/src/helpers/esm-loader.js
@@ -17,6 +17,8 @@ export function resolve(specifier, context, defaultResolver) {
   if (mappedSpecifier) {
     if (mappedSpecifier.match(/(\/\*|\.jsx?|\.tsx?|\.cjs)$/)) {
       specifier = pathToFileURL(mappedSpecifier).pathname;
+    } else if (mappedSpecifier.includes('/dist/')) {
+      specifier = `${pathToFileURL(mappedSpecifier)}.js`;
     } else {
       specifier = `${pathToFileURL(mappedSpecifier)}.ts`;
     }


### PR DESCRIPTION
Update build script for ESM repos

Output will be two entry points:
- `dist/index.js` for ES module import
- `dist/index.cjs` single bundle for commonjs import
