### PR TITLE
Typo in the word require

### DIFF
--- a/modules/dev-tools/docs/api-reference/get-babel-config.md
+++ b/modules/dev-tools/docs/api-reference/get-babel-config.md
@@ -6,7 +6,7 @@ Create a `ocular-dev-tools` default babel config.
 
 ```js
 // babel.config.js
-const {getBabelConfig} = requre('ocular-dev-tools/configuration');
+const {getBabelConfig} = require('ocular-dev-tools/configuration');
 
 module.exports = getBabelConfig({
   /** Enable React preset */


### PR DESCRIPTION
Fixed the typo, though it would be nice if there were also examples that use ESM.