### PR TITLE
[dev-tools] Start vite server from JS API

### DIFF
--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -57,7 +57,7 @@
     "@babel/runtime": "7.14.5",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.0",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.0",
-    "@probe.gl/test-utils": "^3.5.4",
+    "@probe.gl/test-utils": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "babel-loader": "8.2.2",

--- a/modules/dev-tools/src/test.js
+++ b/modules/dev-tools/src/test.js
@@ -111,15 +111,15 @@ async function createViteServer(config) {
     configFile: viteConfigPath,
     mode: config.options?.mode,
     server: {
-      port: config.port,
-    },
+      port: config.port
+    }
   });
   await server.listen();
 
   return {
     url: server.resolvedUrls.local[0],
     stop: () => {
-      server.close()
+      server.close();
     }
   };
 }

--- a/modules/dev-tools/src/test.js
+++ b/modules/dev-tools/src/test.js
@@ -6,6 +6,7 @@ import {execShellCommand} from './utils/shell.js';
 import {getOcularConfig} from './helpers/get-ocular-config.js';
 
 import {BrowserTestDriver} from '@probe.gl/test-utils';
+import {createServer} from 'vite';
 
 const mode = process.argv.length >= 3 ? process.argv[2] : 'default';
 const ocularConfig = await getOcularConfig({aliasMode: mode});
@@ -28,21 +29,13 @@ switch (mode) {
   case 'browser-headless':
     await runBrowserTest({
       server: {
-        command: 'vite',
-        arguments: ['--config', viteConfigPath, '--mode', 'test']
+        start: createViteServer,
+        options: {
+          mode: 'test'
+        }
       },
       url: resolveBrowserEntry('test'),
       headless: mode === 'browser-headless'
-    });
-    break;
-
-  case 'bench-browser':
-    await runBrowserTest({
-      server: {
-        command: 'vite',
-        arguments: ['--config', viteConfigPath, '--mode', 'bench']
-      },
-      url: resolveBrowserEntry('bench')
     });
     break;
 
@@ -51,8 +44,10 @@ switch (mode) {
       const testMode = mode.replace('-browser', '').replace('-headless', '');
       await runBrowserTest({
         server: {
-          command: 'vite',
-          arguments: ['--config', viteConfigPath, '--mode', testMode]
+          start: createViteServer,
+          options: {
+            mode: testMode
+          }
         },
         url: resolveBrowserEntry(testMode),
         headless: /\bheadless\b/.test(mode)
@@ -109,4 +104,22 @@ function runBrowserTest(opts) {
     server: {...opts.server, ...userConfig.server},
     browser: {...opts.browser, ...userConfig.browser}
   });
+}
+
+async function createViteServer(config) {
+  const server = await createServer({
+    configFile: viteConfigPath,
+    mode: config.options?.mode,
+    server: {
+      port: config.port,
+    },
+  });
+  await server.listen();
+
+  return {
+    url: server.resolvedUrls.local[0],
+    stop: () => {
+      server.close()
+    }
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,15 +1177,15 @@
     ts-node "^9"
     tslib "^2"
 
-"@esbuild-plugins/node-globals-polyfill@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz#a313ab3efbb2c17c8ce376aa216c627c9b40f9d7"
-  integrity sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==
+"@esbuild-plugins/node-globals-polyfill@^0.2.0":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz#0e4497a2b53c9e9485e149bc92ddb228438d6bcf"
+  integrity sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==
 
-"@esbuild-plugins/node-modules-polyfill@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz#eb2f55da11967b2986c913f1a7957d1c868849c0"
-  integrity sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==
+"@esbuild-plugins/node-modules-polyfill@^0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz#cefa3dc0bd1c16277a8338b52833420c94987327"
+  integrity sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==
   dependencies:
     escape-string-regexp "^4.0.0"
     rollup-plugin-node-polyfills "^0.2.1"
@@ -2942,10 +2942,10 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@probe.gl/env@3.5.4":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-3.5.4.tgz#faddd1232f607b634fa9f00502b40706e143426d"
-  integrity sha512-MtMINUpcPzAp8upQNbm5U1Hp+/EQ8yw0tXccg5Aiz7cl92LsMopDPtgXnCRv2whzcayioHAdg4YIhNPY5fFxMQ==
+"@probe.gl/env@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-4.0.3.tgz#c437b139953ceda9c1a13bad2be9c14d3ff3ba03"
+  integrity sha512-Iz2/xPHMa5adDBw/m7nyQ0bKgLXZqMauPfV2ePU9ZOfkt6NnWMzQAjBeeXufujE6vndJUAALgpweO/YjYkKo+Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
@@ -2957,13 +2957,13 @@
     "@babel/runtime" "^7.0.0"
     "@probe.gl/env" "3.5.2"
 
-"@probe.gl/log@3.5.4":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-3.5.4.tgz#106c863032242ba1232d7a1afc4acd9905305305"
-  integrity sha512-jnyr6aAdW4PbS55izskE8crpb52hJ/bQwqeJeQywK6sm7Jhh9im2RFbPrjs8CIEVDBqrcwJ1Rm1hEvTKNhKSmA==
+"@probe.gl/log@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-4.0.3.tgz#69c57aac4394f21e7786285028403fa7504bc4f4"
+  integrity sha512-GAvGo87nYAcS/sLs00qts+thzlYPXLzkAG1xdtY3NxeI9oJAo+EU/sw+qcnfews4HO/u60QLMHrQJgSSbCGmjQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/env" "3.5.4"
+    "@probe.gl/env" "4.0.3"
 
 "@probe.gl/stats@3.5.2":
   version "3.5.2"
@@ -2972,13 +2972,14 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@probe.gl/test-utils@^3.5.4":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-3.5.4.tgz#8e79b2eb68b07865d79708e1cf7895f0616ed88e"
-  integrity sha512-NV0esSd6YBDsyMuBkJblCIqtW+XNn3pmDhBe6jPR05xQZo40zcp4xJr/6Nxsw/ZRJU3qeIdG9j3doK+WriTpog==
+"@probe.gl/test-utils@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-4.0.3.tgz#1bddd2543f89d5dcc928784bbf9a9d3b7a22c756"
+  integrity sha512-GV8OX8X2+l8bhUfGu7sgWz4MUopqFLiq8ij+2bese/tFAFXnHcuzQwY7QN8NdBQ/Yxue5EiiAMI5JXZLKvrviQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/log" "3.5.4"
+    "@probe.gl/log" "4.0.3"
+    "@types/pngjs" "^6.0.1"
     pixelmatch "^4.0.2"
     puppeteer "*"
 
@@ -3343,6 +3344,13 @@
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
+
+"@types/pngjs@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pngjs/-/pngjs-6.0.1.tgz#c711ec3fbbf077fed274ecccaf85dd4673130072"
+  integrity sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/prop-types@*":
   version "15.7.5"


### PR DESCRIPTION
After this change, Vite errors should be printed to the console and block the browser test, instead of silently hanging.

- Bump probe.gl dependency to 4.0.3
- Use Vite's JS API to start server instead of CLI + arbitrary wait time
