### PR TITLE
fix(dev-tools) babel config overrides nesting

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -2,7 +2,7 @@ const {getBabelConfig} = require('ocular-dev-tools/configuration');
 
 module.exports = getBabelConfig({
   react: true,
-  overrides: {
+  overrides: [{
     plugins: ['@babel/syntax-import-assertions']
-  }
+  }]
 });

--- a/modules/dev-tools/docs/README.md
+++ b/modules/dev-tools/docs/README.md
@@ -107,7 +107,7 @@ const {getBabelConfig} = require('ocular-dev-tools/configuration');
 module.exports = getBabelConfig({
   react: true,
   // specify custom configs
-  overrides: {}
+  overrides: [{}]
 });
 ```
 

--- a/modules/dev-tools/docs/api-reference/get-babel-config.md
+++ b/modules/dev-tools/docs/api-reference/get-babel-config.md
@@ -12,11 +12,11 @@ module.exports = getBabelConfig({
   /** Enable React preset */
   react: true,
   /** This will be deep merged with the default config */
-  overrides: {
+  overrides: [{
     plugins: [
       // custom plugins
     ]
-  },
+  }],
   /** Print full config JSON for inspection */
   debug: true
 });

--- a/modules/dev-tools/src/configuration/get-babel-config.cjs
+++ b/modules/dev-tools/src/configuration/get-babel-config.cjs
@@ -108,7 +108,7 @@ module.exports.getBabelConfig = function getBabelConfig(options = {}) {
       })
     }
     if (options.overrides) {
-      config = deepMerge(config, options.overrides);
+      config = deepMerge(config, {overrides: options.overrides});
     }
 
     if (options.debug) {

--- a/modules/dev-tools/src/configuration/get-babel-config.d.ts
+++ b/modules/dev-tools/src/configuration/get-babel-config.d.ts
@@ -5,6 +5,6 @@
  */
 export function getBabelConfig(options?: {
   react?: boolean;
-  overrides?: any;
+  overrides?: any[];
   debug?: boolean;
 }): (api: any) => {[key: string]: any};


### PR DESCRIPTION
For #427 

**Changes**
- Babel `overrides` should be nested under `overrides`
- The `overrides` type can be an array or undefined. Babel throws `ConfigError: .overrides must be an array, or undefined` otherwise.