### PR TITLE
Change cjs entry point target

### DIFF
--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -37,7 +37,7 @@ build_module_esm() {
     fi
 
     echo "Bundling ${ENTRY}"
-    esbuild $ENTRY --bundle --packages=external --format=cjs --target=es2015 --outfile=dist/${P}.cjs
+    esbuild $ENTRY --bundle --packages=external --format=cjs --target=node16 --outfile=dist/${P}.cjs
   ); done
 }
 


### PR DESCRIPTION
Change commonjs entry point target from `es2015` to `node16`. This will allow more modern JS features to be included without heavy transpilation and polyfill.

If the cjs entry point is required by Node, the current LTS is v18, and our modules' minimal required version is v16.
If the cjs entry point is required by a bundler, secondary transpilation will usually be applied anyways.