### PR TITLE
feat(dev-tool): Swap to the new chrome headless mode

### DIFF
--- a/modules/dev-tools/src/test.js
+++ b/modules/dev-tools/src/test.js
@@ -35,7 +35,7 @@ switch (mode) {
         }
       },
       url: resolveBrowserEntry('test'),
-      headless: mode === 'browser-headless'
+      headless: mode === 'browser-headless' ? 'new' : false
     });
     break;
 


### PR DESCRIPTION
I and some my colleagues faced with the issue that it's impossible to turn on WebGL context in tests in browser-headless mode on MacBooks with M1 and M2 processors. 
According https://developer.chrome.com/articles/new-headless/ chrome developers plan on completely moving to a new headless mode and I guess they stopped all major fixes on the old one. The good news is that it's fixed in the new mode so that's why I propose to move to the new mode now