### PR TITLE
fix(dev-tools) use new headless mode in browser tests

### DIFF
--- a/modules/dev-tools/src/test.js
+++ b/modules/dev-tools/src/test.js
@@ -35,7 +35,7 @@ switch (mode) {
         }
       },
       url: resolveBrowserEntry('test'),
-      headless: mode === 'browser-headless'
+      headless: mode === 'browser-headless' ? 'new' : false
     });
     break;
 


### PR DESCRIPTION
Hardware GPU's on ARM Macs aren't automatically enabled with the old headless mode, and the swiftshader software driver it uses instead fails to create webgl context.

Stack trace:
```
browser-driver: Loading page in browser...
[log] Failed to create WebGL context: Could not create a WebGL context, VENDOR = 0xffff, DEVICE = 0xffff, GL_VENDOR = Google Inc. (Google), GL_RENDERER = ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver-5.0.0), GL_VERSION = 5.0.0, Sandboxed = yes, Optimus = no, AMD switchable = no, Reset notification strategy = 0x8252, ErrorMessage = BindToCurrentSequence failed: .
```

The new mode creates a webgl context without issue.

Also, this also resolves the warning new versions of puppeteer print about the new headless flag behavior.

Warning:
<img width="783" alt="Screen Shot 2023-10-13 at 1 32 30 PM" src="https://github.com/uber-web/ocular/assets/2461547/b0f56c4b-ca6e-42b2-b0df-6d1a5646d9f8">
More info: https://developer.chrome.com/articles/new-headless/


