### PR TITLE
feat(dev-tools): Inject __VERSION__ when building CJS dist

### DIFF
--- a/modules/dev-tools/scripts/build.sh
+++ b/modules/dev-tools/scripts/build.sh
@@ -37,7 +37,7 @@ build_module_esm() {
     fi
 
     echo "Bundling ${ENTRY}"
-    esbuild $ENTRY --bundle --packages=external --format=cjs --target=node16 --outfile=dist/${P}.cjs
+    esbuild $ENTRY --bundle --packages=external --format=cjs --target=node16 --outfile=dist/${P}.cjs ----define:__VERSION__=\\\"$npm_package_version\\\"
   ); done
 }
 


### PR DESCRIPTION
- We get failures in loaders.gl 4.0 when using workers from applications that bundle via CJS. 
- We can see that __VERSION__ has not been defined in the CJS bundle.
- Add a define statement when building CJS, same as is done by all explicit esbuild commands in loaders.gl