### PR TITLE
fix: prettier log level

### DIFF
--- a/modules/dev-tools/scripts/lint.sh
+++ b/modules/dev-tools/scripts/lint.sh
@@ -66,7 +66,7 @@ case $MODE in
     (set -x; npx eslint --fix "$DIRECTORIES/**/*.$EXTENSIONS")
 
     print_yellow "Running prettier in $DIRECTORIES..."
-    (set -x; npx prettier --loglevel warn --write "$DIR_PATTERN" "$ROOT_PATTERN")
+    (set -x; npx prettier --log-level warn --write "$DIR_PATTERN" "$ROOT_PATTERN")
     ;;
 
   *)


### PR DESCRIPTION
Fixing prettier log level typo. Not sure what log level we actually want, or if `warn` is already the default, but tired of seeing this warning.

![image](https://github.com/uber-web/ocular/assets/7025232/41953f0d-41a8-4c18-aa99-462dcc714b35)
