### PR TITLE
Add option to report code coverage against browser test

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = getESLintConfig({
     rules: {
       'import/no-extraneous-dependencies': 0,
       'no-console': 0,
+      'no-continue': 0,
       'no-process-env': 0,
       'no-process-exit': 0
     },

--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -58,7 +58,7 @@
     "@babel/runtime": "7.14.5",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.0",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.0",
-    "@probe.gl/test-utils": "^4.0.5",
+    "@probe.gl/test-utils": "^4.0.6",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "babel-loader": "8.2.2",

--- a/modules/dev-tools/scripts/test.sh
+++ b/modules/dev-tools/scripts/test.sh
@@ -56,7 +56,8 @@ case $MODE in
     ;;
 
   "cover")
-    (set -x; npx c8 node $TEST_SCRIPT cover)
+    run_test_script cover
+    # (set -x; npx c8 node $TEST_SCRIPT cover)
     (set -x; npx c8 report --reporter=lcov)
     ;;
 

--- a/modules/dev-tools/src/helpers/get-ocular-config.d.ts
+++ b/modules/dev-tools/src/helpers/get-ocular-config.d.ts
@@ -35,6 +35,10 @@ type OcularConfig = {
     configPath?: string;
   };
 
+  coverage?: {
+    test?: 'node' | 'browser';
+  };
+
   browserTest?: {
     server?: string;
     browser?: string;
@@ -82,6 +86,10 @@ type MaterializedOcularConfig = {
   vite: {
     version: number;
     configPath: string;
+  };
+
+  coverage: {
+    test: 'node' | 'browser';
   };
 
   browserTest?: {

--- a/modules/dev-tools/src/helpers/get-ocular-config.js
+++ b/modules/dev-tools/src/helpers/get-ocular-config.js
@@ -46,6 +46,10 @@ export async function getOcularConfig(options = {}) {
       extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx', 'd.ts']
     },
 
+    coverage: {
+      test: 'node'
+    },
+
     aliases: {},
 
     entry: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,28 +2368,28 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
-"@probe.gl/env@4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-4.0.5.tgz#3e6e7080d3dd38764f90acdf112dfd38eab5273c"
-  integrity sha512-B9urUsFaXWl0OlSLXOoSI03b84sdgtYCOwtohNoyg6DaNMK9Hlfau6b0c0msTMu0TiA/kM/rX7MnAHv6FCcKEA==
+"@probe.gl/env@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-4.0.6.tgz#ea73bfb60ed862dd37654b833ca2e38160d53f8b"
+  integrity sha512-nF7/LrBgp5YU2va+7pgKRHbh22zK8OIUhVw/N1O9pqM9AbifIGwoi0rFN5QIO4bxAvxcC6iUutgLQq5Y5yRr8A==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@probe.gl/log@4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-4.0.5.tgz#66ccce92e1ad74caf6c39ad101f1e731f407f750"
-  integrity sha512-5otC74VzKljMnrkFFeZYJRYth/UzDH+UCZOVi1kTkAMquglLnKNC4SuprsO2mFv1Ycl3O8G/6wZkjx8izn7gaQ==
+"@probe.gl/log@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-4.0.6.tgz#820808bb958b9ec4df588ade684bed60ce2195ff"
+  integrity sha512-w4rESrMxLF+nsgxqBFUMlf/dFwOW3o+PDBzl5pAPpyhiYCUEwYCTgD4FwE/uguzpK1Q+ms3fDF7jSnoIqMR0fQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/env" "4.0.5"
+    "@probe.gl/env" "4.0.6"
 
-"@probe.gl/test-utils@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-4.0.5.tgz#da326c89ae49e14ec659e7e9f65f1df32bddaed1"
-  integrity sha512-2/KmY4tdMCgPPS1vZccUIBHJQfrJCQzp/RXHv5gitkVSOOf3O+m0s3jLGBsL/Co4o9lSYsOYuVLB6MK5Dn/bfQ==
+"@probe.gl/test-utils@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-4.0.6.tgz#2eee7a4e0774256056f7bd9503aabe822a475143"
+  integrity sha512-ZlkpCL+9ognfVezaf7ZTcGFE9iFAOhlMAsSkZH6Yht6U/wkL6duvTCk9pioE5zHtAa4zKRGY2bWCm77QdxFVgg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/log" "4.0.5"
+    "@probe.gl/log" "4.0.6"
     "@types/pngjs" "^6.0.1"
     pixelmatch "^4.0.2"
 


### PR DESCRIPTION
Set ocular config `coverage.test: 'browser'` to get coverage from browser test.