### PR TITLE
feat(dev-tools): Inline ESM-only dependency

### DIFF
--- a/modules/dev-tools/src/configuration/get-esbuild-config.ts
+++ b/modules/dev-tools/src/configuration/get-esbuild-config.ts
@@ -73,14 +73,13 @@ function umdWrapper(libName: string | undefined) {
  */
 const inlineESMOnly = (): Plugin => {
   const packageRoot = process.cwd();
-  const root = join(packageRoot, '../..');
 
   return {
     name: 'inline-esm-only',
     setup(build) {
       // TODO: Detect ESM-only from package.json, instead of hard-coding package names?
       build.onResolve({filter: /^@mapbox\/tiny\-sdf$/}, () => {
-        const path = join(root, 'node_modules/@mapbox/tiny-sdf/index.js');
+        const path = join(packageRoot, 'node_modules/@mapbox/tiny-sdf/index.js');
         return {path, external: false};
       });
     }


### PR DESCRIPTION
For discussion. 

As of v9, deck.gl provides both ESM and CJS entrypoints. However, some dependencies — [notably `@mapbox/tiny-sdf`](https://github.com/mapbox/tiny-sdf/issues/53) — are ESM-only and do not include CJS entrypoints. This seems to be a problem in certain environments as noted in https://github.com/visgl/deck.gl/issues/7735, which may require CJS versions of dependencies.

This PR implements a possible solution in which the `@mapbox/tiny-sdf` dependency is inlined into the compiled CJS bundle. Optionally, we could do the same for the ESM bundle, and move the package from dependencies to devDependencies. The module is small (1.2kB), and can be tree-shaken, so the inlining seems acceptable.

I assume that if we decide to take this approach, we'd change the API such that the package name is not hard coded into ocular-dev-tools, and we instead either pass a list of package names in the project's ocular config, or attempt to automatically detect which dependencies do not offer CJS entrypoints.

Alternatives considered:

- Replace `@mapbox/tiny-sdf` with an alternative
- Fork `@mapbox/tiny-sdf`, add CJS build
- Drop CJS support in deck.gl