### PR TITLE
fix(dev-tools): drop deprecated node option

### DIFF
--- a/modules/dev-tools/src/helpers/esm-register.ts
+++ b/modules/dev-tools/src/helpers/esm-register.ts
@@ -1,0 +1,4 @@
+import {register} from 'node:module';
+
+register('ts-node/esm', import.meta.url);
+register('./esm-alias.js', import.meta.url);

--- a/modules/dev-tools/src/test.ts
+++ b/modules/dev-tools/src/test.ts
@@ -109,7 +109,7 @@ function runNodeTest(entry: string, command: string = '') {
 
   if (ocularConfig.esm) {
     execShellCommand(
-      `NODE_OPTIONS="--experimental-modules --es-module-specifier-resolution=node --loader ${ocularConfig.ocularPath}/dist/helpers/esm-loader.js" ${command} node "${entry}"`
+      `${command} node --import "${ocularConfig.ocularPath}/dist/helpers/esm-register.js" --es-module-specifier-resolution=node "${entry}"`
     );
   } else {
     execShellCommand(

--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
   },
   "pre-commit": "pre-commit",
   "pre-push": "pre-push",
-  "dependencies": {}
+  "dependencies": {},
+  "volta": {
+    "node": "18.19.0",
+    "yarn": "1.22.19"
+  }
 }


### PR DESCRIPTION
- Drop deprecated node option `--loader`, use `--import`
- Requires Node 18 LTS+